### PR TITLE
fix: streamText fails to send `chat` span silently with AI SDK v4

### DIFF
--- a/.github/workflows/release-ai-sdk.yaml
+++ b/.github/workflows/release-ai-sdk.yaml
@@ -21,5 +21,5 @@ jobs:
           token: ${{ secrets.AXIOM_AUTOMATION_TOKEN }}
           # this is a built-in strategy in release-please, see "Action Inputs"
           # for more options
-          release-type: node
           path: packages/ai
+          # 🚨 all other config is in `release-please-config.json`

--- a/examples/example-instrumentation-nextjs-v4/package.json
+++ b/examples/example-instrumentation-nextjs-v4/package.json
@@ -29,6 +29,6 @@
   "devDependencies": {
     "@types/node": "18.7.11",
     "@types/react": "18.2.8",
-    "typescript": "^5.0.0"
+    "typescript": "^5.7.2"
   }
 }

--- a/examples/example-instrumentation-nextjs-v4/src/app/generate-text/loading.tsx
+++ b/examples/example-instrumentation-nextjs-v4/src/app/generate-text/loading.tsx
@@ -1,0 +1,7 @@
+export default async function Loading() {
+  return (
+    <div>
+      <p>Loading...</p>
+    </div>
+  );
+}

--- a/examples/example-instrumentation-nextjs-v4/src/app/generate-text/page.tsx
+++ b/examples/example-instrumentation-nextjs-v4/src/app/generate-text/page.tsx
@@ -38,7 +38,7 @@ export default async function Page() {
               // Simulate API call delay
               await new Promise((resolve) => setTimeout(resolve, 500));
 
-              // Return mock weather data
+              // Return mock directions data
               return {
                 from,
                 to,

--- a/examples/example-instrumentation-nextjs-v4/src/app/generate-text/page.tsx
+++ b/examples/example-instrumentation-nextjs-v4/src/app/generate-text/page.tsx
@@ -1,0 +1,60 @@
+import { generateText, tool } from 'ai';
+import { z } from 'zod';
+import { gpt4oMini } from '@/shared/openai';
+import { withSpan, wrapTool } from '@axiomhq/ai';
+
+export const dynamic = 'force-dynamic';
+
+export default async function Page() {
+  const userId = 123;
+  const res = await withSpan({ capability: 'help_user', step: 'get_weather' }, (span) => {
+    // you have access to the span in this callback
+    span.setAttribute('user_id', userId);
+
+    return generateText({
+      model: gpt4oMini,
+      maxSteps: 5,
+      messages: [
+        {
+          role: 'system',
+          content:
+            'You are a helpful AI assistant. You must always use the findDirections tool when asked to find directions.',
+        },
+        {
+          role: 'user',
+          content: 'How do I get from Paris to Berlin?',
+        },
+      ],
+      tools: {
+        findDirections: wrapTool(
+          'findDirections',
+          tool({
+            description: 'Find directions to a location',
+            parameters: z.object({
+              from: z.string().describe('The location to start from'),
+              to: z.string().describe('The location to find directions to'),
+            }),
+            execute: async ({ from, to }, opts) => {
+              // Simulate API call delay
+              await new Promise((resolve) => setTimeout(resolve, 500));
+
+              // Return mock weather data
+              return {
+                from,
+                to,
+                directions: `To get from ${from} to ${to}, use a teleporter.`,
+              };
+            },
+          }),
+        ),
+      },
+    });
+  });
+
+  return (
+    <div>
+      <p>{res.text}</p>
+      <pre>messages: {JSON.stringify(res.response.messages, null, 2)}</pre>
+    </div>
+  );
+}

--- a/examples/example-instrumentation-nextjs-v4/src/app/layout.tsx
+++ b/examples/example-instrumentation-nextjs-v4/src/app/layout.tsx
@@ -8,7 +8,10 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body>
+        <h1>Next.js with Vercel AI SDK v4 and @axiomhq/ai</h1>
+        {children}
+      </body>
     </html>
   );
 }

--- a/examples/example-instrumentation-nextjs-v4/src/app/page.tsx
+++ b/examples/example-instrumentation-nextjs-v4/src/app/page.tsx
@@ -1,60 +1,18 @@
-import { generateText, tool } from 'ai';
-import { z } from 'zod';
-import { gpt4oMini } from '@/shared/openai';
-import { withSpan, wrapTool } from '@axiomhq/ai';
+import Link from 'next/link';
 
-export const dynamic = 'force-dynamic';
-
-export default async function Page() {
-  const userId = 123;
-  const res = await withSpan({ capability: 'help_user', step: 'get_weather' }, (span) => {
-    // you have access to the span in this callback
-    span.setAttribute('user_id', userId);
-
-    return generateText({
-      model: gpt4oMini,
-      maxSteps: 5,
-      messages: [
-        {
-          role: 'system',
-          content:
-            'You are a helpful AI assistant. You must always use the findDirections tool when asked to find directions.',
-        },
-        {
-          role: 'user',
-          content: 'How do I get from Paris to Berlin?',
-        },
-      ],
-      tools: {
-        findDirections: wrapTool(
-          'findDirections',
-          tool({
-            description: 'Find directions to a location',
-            parameters: z.object({
-              from: z.string().describe('The location to start from'),
-              to: z.string().describe('The location to find directions to'),
-            }),
-            execute: async ({ from, to }, opts) => {
-              // Simulate API call delay
-              await new Promise((resolve) => setTimeout(resolve, 500));
-
-              // Return mock weather data
-              return {
-                from,
-                to,
-                directions: `To get from ${from} to ${to}, use a teleporter.`,
-              };
-            },
-          }),
-        ),
-      },
-    });
-  });
-
+export default function Page() {
   return (
     <div>
-      <p>{res.text}</p>
-      <pre>messages: {JSON.stringify(res.response.messages, null, 2)}</pre>
+      <h1>Axiom AI Examples</h1>
+      <p>Choose an example to explore:</p>
+      <ul>
+        <li>
+          <Link href="/generate-text">Generate Text Example</Link>
+        </li>
+        <li>
+          <Link href="/stream-text">Stream Text Example</Link>
+        </li>
+      </ul>
     </div>
   );
 }

--- a/examples/example-instrumentation-nextjs-v4/src/app/stream-text/actions.ts
+++ b/examples/example-instrumentation-nextjs-v4/src/app/stream-text/actions.ts
@@ -1,0 +1,28 @@
+'use server';
+
+import { streamText } from 'ai';
+import { createOpenAI } from '@ai-sdk/openai';
+import { createStreamableValue } from 'ai/rsc';
+
+const openai = createOpenAI({
+  apiKey: process.env.OPENAI_API_KEY!,
+});
+
+export async function generateStreamingText(input: string) {
+  const stream = createStreamableValue('');
+
+  (async () => {
+    const { textStream } = streamText({
+      model: openai('gpt-4o-mini'),
+      prompt: input,
+    });
+
+    for await (const delta of textStream) {
+      stream.update(delta);
+    }
+
+    stream.done();
+  })();
+
+  return { output: stream.value };
+}

--- a/examples/example-instrumentation-nextjs-v4/src/app/stream-text/actions.ts
+++ b/examples/example-instrumentation-nextjs-v4/src/app/stream-text/actions.ts
@@ -3,6 +3,8 @@
 import { streamText } from 'ai';
 import { createOpenAI } from '@ai-sdk/openai';
 import { createStreamableValue } from 'ai/rsc';
+import { withSpan } from '@axiomhq/ai';
+import { gpt4oMini } from '@/shared/openai';
 
 const openai = createOpenAI({
   apiKey: process.env.OPENAI_API_KEY!,
@@ -12,16 +14,18 @@ export async function generateStreamingText(input: string) {
   const stream = createStreamableValue('');
 
   (async () => {
-    const { textStream } = streamText({
-      model: openai('gpt-4o-mini'),
-      prompt: input,
+    withSpan({ capability: 'example', step: 'stream' }, async () => {
+      const { textStream } = streamText({
+        model: gpt4oMini,
+        prompt: input,
+      });
+
+      for await (const delta of textStream) {
+        stream.update(delta);
+      }
+
+      stream.done();
     });
-
-    for await (const delta of textStream) {
-      stream.update(delta);
-    }
-
-    stream.done();
   })();
 
   return { output: stream.value };

--- a/examples/example-instrumentation-nextjs-v4/src/app/stream-text/page.tsx
+++ b/examples/example-instrumentation-nextjs-v4/src/app/stream-text/page.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import { useState } from 'react';
+import { generateStreamingText } from './actions';
+import { readStreamableValue } from 'ai/rsc';
+
+export const maxDuration = 30;
+
+export default function Page() {
+  const [input, setInput] = useState('');
+  const [generation, setGeneration] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!input.trim()) return;
+
+    setIsLoading(true);
+    setGeneration('');
+
+    try {
+      const { output } = await generateStreamingText(input);
+
+      for await (const delta of readStreamableValue(output)) {
+        setGeneration((currentGeneration) => `${currentGeneration}${delta}`);
+      }
+    } catch (error) {
+      console.error('Error generating text:', error);
+      setGeneration('Error generating text. Please try again.');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div>
+      <h1>Stream Text Example</h1>
+      <p>Enter a prompt to see streaming text generation in action:</p>
+
+      <form onSubmit={handleSubmit} style={{ marginBottom: '20px' }}>
+        <div style={{ marginBottom: '10px' }}>
+          <textarea
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            placeholder="Enter your prompt here..."
+            rows={4}
+            style={{
+              width: '100%',
+              padding: '8px',
+              borderRadius: '4px',
+              border: '1px solid #ccc',
+            }}
+            disabled={isLoading}
+          />
+        </div>
+        <button
+          type="submit"
+          disabled={isLoading || !input.trim()}
+          style={{
+            padding: '8px 16px',
+            backgroundColor: isLoading ? '#ccc' : '#007cba',
+            color: 'white',
+            border: 'none',
+            borderRadius: '4px',
+            cursor: isLoading ? 'not-allowed' : 'pointer',
+          }}
+        >
+          {isLoading ? 'Generating...' : 'Generate'}
+        </button>
+      </form>
+
+      {(generation || isLoading) && (
+        <div
+          style={{
+            marginTop: '20px',
+            padding: '16px',
+            backgroundColor: '#f5f5f5',
+            borderRadius: '4px',
+            border: '1px solid #ddd',
+            whiteSpace: 'pre-wrap',
+          }}
+        >
+          <h3>Generated Text:</h3>
+          <div>{generation || (isLoading ? 'Starting generation...' : '')}</div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/examples/example-instrumentation-nextjs-v4/src/shared/openai.ts
+++ b/examples/example-instrumentation-nextjs-v4/src/shared/openai.ts
@@ -3,6 +3,7 @@ import { wrapAISDKModel } from '@axiomhq/ai';
 
 const openai = createOpenAI({
   apiKey: process.env.OPENAI_API_KEY!,
+  compatibility: 'strict',
 });
 
 export const gpt4oMini = wrapAISDKModel(openai('gpt-4o-mini'));

--- a/examples/example-instrumentation-nextjs-v4/tsconfig.json
+++ b/examples/example-instrumentation-nextjs-v4/tsconfig.json
@@ -9,7 +9,7 @@
     "noEmit": true,
     "esModuleInterop": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",

--- a/examples/example-instrumentation-nextjs-v5/package.json
+++ b/examples/example-instrumentation-nextjs-v5/package.json
@@ -7,6 +7,8 @@
   },
   "dependencies": {
     "@ai-sdk/openai": "2.0.0-beta.11",
+    "@ai-sdk/react": "2.0.0-beta.25",
+    "@ai-sdk/rsc": "1.0.0-beta.25",
     "@axiomhq/ai": "workspace:*",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/exporter-jaeger": "^2.0.1",
@@ -24,6 +26,6 @@
   "devDependencies": {
     "@types/node": "18.7.11",
     "@types/react": "18.2.8",
-    "typescript": "4.7.4"
+    "typescript": "^5.7.2"
   }
 }

--- a/examples/example-instrumentation-nextjs-v5/src/app/generate-text/loading.tsx
+++ b/examples/example-instrumentation-nextjs-v5/src/app/generate-text/loading.tsx
@@ -1,0 +1,7 @@
+export default async function Loading() {
+  return (
+    <div>
+      <p>Loading...</p>
+    </div>
+  );
+}

--- a/examples/example-instrumentation-nextjs-v5/src/app/generate-text/loading.tsx
+++ b/examples/example-instrumentation-nextjs-v5/src/app/generate-text/loading.tsx
@@ -1,4 +1,4 @@
-export default async function Loading() {
+export default function Loading() {
   return (
     <div>
       <p>Loading...</p>

--- a/examples/example-instrumentation-nextjs-v5/src/app/generate-text/page.tsx
+++ b/examples/example-instrumentation-nextjs-v5/src/app/generate-text/page.tsx
@@ -1,0 +1,61 @@
+import { generateText, stepCountIs, tool } from 'ai';
+import { z } from 'zod';
+import { gpt4oMini } from '@/shared/openai';
+import { withSpan, wrapTool } from '@axiomhq/ai';
+
+export const dynamic = 'force-dynamic';
+
+export default async function Page() {
+  const userId = 123;
+  const res = await withSpan({ capability: 'help_user', step: 'get_weather' }, (span) => {
+    // you have access to the span in this callback
+    span.setAttribute('user_id', userId);
+
+    return generateText({
+      model: gpt4oMini,
+      stopWhen: stepCountIs(5),
+      messages: [
+        {
+          role: 'system',
+          content:
+            'You are a helpful AI assistant. You must always use the findDirections tool when asked to find directions.',
+        },
+        {
+          role: 'user',
+          content: 'How do I get from Paris to Berlin?',
+        },
+      ],
+      tools: {
+        findDirections: wrapTool(
+          'findDirections',
+          tool({
+            description: 'Find directions to a location',
+            inputSchema: z.object({
+              from: z.string().describe('The location to start from'),
+              to: z.string().describe('The location to find directions to'),
+            }),
+            execute: async (params, opts) => {
+              const { from, to } = params;
+              // Simulate API call delay
+              await new Promise((resolve) => setTimeout(resolve, 500));
+
+              // Return mock weather data
+              return {
+                from,
+                to,
+                directions: `To get from ${from} to ${to}, use a teleporter.`,
+              };
+            },
+          }),
+        ),
+      },
+    });
+  });
+
+  return (
+    <div>
+      <p>{res.text}</p>
+      <pre>messages: {JSON.stringify(res.response.messages, null, 2)}</pre>
+    </div>
+  );
+}

--- a/examples/example-instrumentation-nextjs-v5/src/app/generate-text/page.tsx
+++ b/examples/example-instrumentation-nextjs-v5/src/app/generate-text/page.tsx
@@ -39,7 +39,7 @@ export default async function Page() {
               // Simulate API call delay
               await new Promise((resolve) => setTimeout(resolve, 500));
 
-              // Return mock weather data
+              // Return mock directions data
               return {
                 from,
                 to,

--- a/examples/example-instrumentation-nextjs-v5/src/app/layout.tsx
+++ b/examples/example-instrumentation-nextjs-v5/src/app/layout.tsx
@@ -8,7 +8,10 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body>
+        <h1>Next.js with Vercel AI SDK v5 and @axiomhq/ai</h1>
+        {children}
+      </body>
     </html>
   );
 }

--- a/examples/example-instrumentation-nextjs-v5/src/app/page.tsx
+++ b/examples/example-instrumentation-nextjs-v5/src/app/page.tsx
@@ -1,61 +1,18 @@
-import { generateText, stepCountIs, tool } from 'ai';
-import { z } from 'zod';
-import { gpt4oMini } from '@/shared/openai';
-import { withSpan, wrapTool } from '@axiomhq/ai';
+import Link from 'next/link';
 
-export const dynamic = 'force-dynamic';
-
-export default async function Page() {
-  const userId = 123;
-  const res = await withSpan({ capability: 'help_user', step: 'get_weather' }, (span) => {
-    // you have access to the span in this callback
-    span.setAttribute('user_id', userId);
-
-    return generateText({
-      model: gpt4oMini,
-      stopWhen: stepCountIs(5),
-      messages: [
-        {
-          role: 'system',
-          content:
-            'You are a helpful AI assistant. You must always use the findDirections tool when asked to find directions.',
-        },
-        {
-          role: 'user',
-          content: 'How do I get from Paris to Berlin?',
-        },
-      ],
-      tools: {
-        findDirections: wrapTool(
-          'findDirections',
-          tool({
-            description: 'Find directions to a location',
-            inputSchema: z.object({
-              from: z.string().describe('The location to start from'),
-              to: z.string().describe('The location to find directions to'),
-            }),
-            execute: async (params, opts) => {
-              const { from, to } = params;
-              // Simulate API call delay
-              await new Promise((resolve) => setTimeout(resolve, 500));
-
-              // Return mock weather data
-              return {
-                from,
-                to,
-                directions: `To get from ${from} to ${to}, use a teleporter.`,
-              };
-            },
-          }),
-        ),
-      },
-    });
-  });
-
+export default function Page() {
   return (
     <div>
-      <p>{res.text}</p>
-      <pre>messages: {JSON.stringify(res.response.messages, null, 2)}</pre>
+      <h1>Axiom AI Examples</h1>
+      <p>Choose an example to explore:</p>
+      <ul>
+        <li>
+          <Link href="/generate-text">Generate Text Example</Link>
+        </li>
+        <li>
+          <Link href="/stream-text">Stream Text Example</Link>
+        </li>
+      </ul>
     </div>
   );
 }

--- a/examples/example-instrumentation-nextjs-v5/src/app/stream-text/actions.ts
+++ b/examples/example-instrumentation-nextjs-v5/src/app/stream-text/actions.ts
@@ -1,0 +1,28 @@
+'use server';
+
+import { streamText } from 'ai';
+import { createOpenAI } from '@ai-sdk/openai';
+import { createStreamableValue } from '@ai-sdk/rsc';
+
+const openai = createOpenAI({
+  apiKey: process.env.OPENAI_API_KEY!,
+});
+
+export async function generateStreamingText(input: string) {
+  const stream = createStreamableValue('');
+
+  (async () => {
+    const { textStream } = streamText({
+      model: openai('gpt-4o-mini'),
+      prompt: input,
+    });
+
+    for await (const delta of textStream) {
+      stream.update(delta);
+    }
+
+    stream.done();
+  })();
+
+  return { output: stream.value };
+}

--- a/examples/example-instrumentation-nextjs-v5/src/app/stream-text/page.tsx
+++ b/examples/example-instrumentation-nextjs-v5/src/app/stream-text/page.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import { useState } from 'react';
+import { generateStreamingText } from './actions';
+import { readStreamableValue } from '@ai-sdk/rsc';
+
+export const maxDuration = 30;
+
+export default function Page() {
+  const [input, setInput] = useState('');
+  const [generation, setGeneration] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!input.trim()) return;
+
+    setIsLoading(true);
+    setGeneration('');
+
+    try {
+      const { output } = await generateStreamingText(input);
+
+      for await (const delta of readStreamableValue(output)) {
+        setGeneration((currentGeneration) => `${currentGeneration}${delta}`);
+      }
+    } catch (error) {
+      console.error('Error generating text:', error);
+      setGeneration('Error generating text. Please try again.');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div>
+      <h1>Stream Text Example</h1>
+      <p>Enter a prompt to see streaming text generation in action:</p>
+
+      <form onSubmit={handleSubmit} style={{ marginBottom: '20px' }}>
+        <div style={{ marginBottom: '10px' }}>
+          <textarea
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            placeholder="Enter your prompt here..."
+            rows={4}
+            style={{
+              width: '100%',
+              padding: '8px',
+              borderRadius: '4px',
+              border: '1px solid #ccc',
+            }}
+            disabled={isLoading}
+          />
+        </div>
+        <button
+          type="submit"
+          disabled={isLoading || !input.trim()}
+          style={{
+            padding: '8px 16px',
+            backgroundColor: isLoading ? '#ccc' : '#007cba',
+            color: 'white',
+            border: 'none',
+            borderRadius: '4px',
+            cursor: isLoading ? 'not-allowed' : 'pointer',
+          }}
+        >
+          {isLoading ? 'Generating...' : 'Generate'}
+        </button>
+      </form>
+
+      {(generation || isLoading) && (
+        <div
+          style={{
+            marginTop: '20px',
+            padding: '16px',
+            backgroundColor: '#f5f5f5',
+            borderRadius: '4px',
+            border: '1px solid #ddd',
+            whiteSpace: 'pre-wrap',
+          }}
+        >
+          <h3>Generated Text:</h3>
+          <div>{generation || (isLoading ? 'Starting generation...' : '')}</div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/examples/example-instrumentation-nextjs-v5/tsconfig.json
+++ b/examples/example-instrumentation-nextjs-v5/tsconfig.json
@@ -9,7 +9,7 @@
     "noEmit": true,
     "esModuleInterop": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axiomhq/ai",
-  "version": "0.0.3",
+  "version": "0.0.2",
   "type": "module",
   "author": "Axiom, Inc.",
   "contributors": [

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axiomhq/ai",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "type": "module",
   "author": "Axiom, Inc.",
   "contributors": [

--- a/packages/ai/src/otel/AxiomWrappedLanguageModelV1.ts
+++ b/packages/ai/src/otel/AxiomWrappedLanguageModelV1.ts
@@ -288,9 +288,26 @@ function buildSpanAttributes(
     attributes[Attr.GenAI.Response.Model] = result.response.modelId;
   }
 
-  if (result.usage) {
-    attributes[Attr.GenAI.Usage.InputTokens] = result.usage.promptTokens;
-    attributes[Attr.GenAI.Usage.OutputTokens] = result.usage.completionTokens;
+  if (result.usage?.promptTokens) {
+    if (Number.isNaN(result.usage.promptTokens)) {
+      console.warn(
+        'usage.promptTokens is NaN. You might need to enable `compatibility: strict`. See: https://github.com/vercel/ai/discussions/1882',
+        result.usage.promptTokens,
+      );
+    } else {
+      attributes[Attr.GenAI.Usage.InputTokens] = result.usage.promptTokens;
+    }
+  }
+
+  if (result.usage?.completionTokens) {
+    if (Number.isNaN(result.usage.completionTokens)) {
+      console.warn(
+        'usage.completionTokens is NaN. You might need to enable `compatibility: strict`. See: https://github.com/vercel/ai/discussions/1882',
+        result.usage.completionTokens,
+      );
+    } else {
+      attributes[Attr.GenAI.Usage.OutputTokens] = result.usage.completionTokens;
+    }
   }
 
   if (result.finishReason) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -167,7 +167,7 @@ importers:
         specifier: 18.2.8
         version: 18.2.8
       typescript:
-        specifier: ^5.0.0
+        specifier: ^5.7.2
         version: 5.8.3
 
   examples/example-instrumentation-nextjs-v5:
@@ -175,6 +175,12 @@ importers:
       '@ai-sdk/openai':
         specifier: 2.0.0-beta.11
         version: 2.0.0-beta.11(zod@3.25.76)
+      '@ai-sdk/react':
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25(react@18.3.1)(zod@3.25.76)
+      '@ai-sdk/rsc':
+        specifier: 1.0.0-beta.25
+        version: 1.0.0-beta.25(react@18.3.1)(zod@3.25.76)
       '@axiomhq/ai':
         specifier: workspace:*
         version: link:../../packages/ai
@@ -222,8 +228,8 @@ importers:
         specifier: 18.2.8
         version: 18.2.8
       typescript:
-        specifier: 4.7.4
-        version: 4.7.4
+        specifier: ^5.7.2
+        version: 5.8.3
 
   internal/eslint-config:
     devDependencies:
@@ -372,6 +378,12 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4
 
+  '@ai-sdk/gateway@1.0.0-beta.11':
+    resolution: {integrity: sha512-dnRUPzSLvp3xvIx6M4FIz4ht8dfL8JkPKwH+akj10im4zbxUii3c3TQ3BJLRdx2Gq/SeljE9H0dX7PDtVyIrbQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4
+
   '@ai-sdk/gateway@1.0.0-beta.9':
     resolution: {integrity: sha512-lr0pmit6oAXPKkyN1QsxHOESiWiIb/jheiO+xiZnidjoZz2V7Se0drW1FH7sinheyK5EjmFMLW+0gBERyo33Ng==}
     engines: {node: '>=18'}
@@ -434,6 +446,26 @@ packages:
     peerDependencies:
       react: ^18 || ^19 || ^19.0.0-rc
       zod: ^3.23.8
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
+  '@ai-sdk/react@2.0.0-beta.25':
+    resolution: {integrity: sha512-3f3f/z3idsH+sctQJ7t0enFywzIbHXDM6a3tvdPMX1dI53mAsVfyhaHzz8WT9swW3Mmphj0i5fZCH4t78m0L4A==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^18 || ^19 || ^19.0.0-rc
+      zod: ^3.25.76 || ^4
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
+  '@ai-sdk/rsc@1.0.0-beta.25':
+    resolution: {integrity: sha512-z+77ZCTam/F5K4Eizja6xZNnySYIxxvzJX2SuvqLzMHWxsvDo3M5qwe3orJefVScNtm/QvwjuIiFYzt19rR/xw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^18 || ^19 || ^19.0.0-rc
+      zod: ^3.25.76 || ^4
     peerDependenciesMeta:
       zod:
         optional: true
@@ -1897,6 +1929,13 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4
 
+  ai@5.0.0-beta.25:
+    resolution: {integrity: sha512-pbfFqtQvz7hiDw6TwUH75CK9FgrZFBsxqbW4yW0aqluHw3nRbhf0w1u2AMiYgvWMy8Xf8TkBbMtY4vyMc4neeA==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.76 || ^4
+
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
 
@@ -3333,11 +3372,6 @@ packages:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <5.9.0'
 
-  typescript@4.7.4:
-    resolution: {integrity: sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==}
-    engines: {node: '>=4.2.0'}
-    hasBin: true
-
   typescript@5.8.3:
     resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
     engines: {node: '>=14.17'}
@@ -3534,6 +3568,12 @@ snapshots:
       '@ai-sdk/provider-utils': 3.0.0-beta.5(zod@3.25.76)
       zod: 3.25.76
 
+  '@ai-sdk/gateway@1.0.0-beta.11(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 2.0.0-beta.1
+      '@ai-sdk/provider-utils': 3.0.0-beta.5(zod@3.25.76)
+      zod: 3.25.76
+
   '@ai-sdk/gateway@1.0.0-beta.9(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 2.0.0-beta.1
@@ -3614,6 +3654,26 @@ snapshots:
       react: 19.1.0
       swr: 2.3.4(react@19.1.0)
       throttleit: 2.1.0
+    optionalDependencies:
+      zod: 3.25.76
+
+  '@ai-sdk/react@2.0.0-beta.25(react@18.3.1)(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider-utils': 3.0.0-beta.5(zod@3.25.76)
+      ai: 5.0.0-beta.25(zod@3.25.76)
+      react: 18.3.1
+      swr: 2.3.4(react@18.3.1)
+      throttleit: 2.1.0
+    optionalDependencies:
+      zod: 3.25.76
+
+  '@ai-sdk/rsc@1.0.0-beta.25(react@18.3.1)(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 2.0.0-beta.1
+      '@ai-sdk/provider-utils': 3.0.0-beta.5(zod@3.25.76)
+      ai: 5.0.0-beta.25(zod@3.25.76)
+      jsondiffpatch: 0.6.0
+      react: 18.3.1
     optionalDependencies:
       zod: 3.25.76
 
@@ -5249,6 +5309,14 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       zod: 3.25.76
 
+  ai@5.0.0-beta.25(zod@3.25.76):
+    dependencies:
+      '@ai-sdk/gateway': 1.0.0-beta.11(zod@3.25.76)
+      '@ai-sdk/provider': 2.0.0-beta.1
+      '@ai-sdk/provider-utils': 3.0.0-beta.5(zod@3.25.76)
+      '@opentelemetry/api': 1.9.0
+      zod: 3.25.76
+
   ajv@6.12.6:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -6776,8 +6844,6 @@ snapshots:
       typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
-
-  typescript@4.7.4: {}
 
   typescript@5.8.3: {}
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,5 @@
+{
+    "release-type": "node",
+    "versioning-strategy": "always-bump-patch",
+    "include-v-in-tag": true
+}


### PR DESCRIPTION
- Add working `streamText` example to Next.js examples (both AI SDK v4 and v5)
- Warn if `streamText` returns `NaN` tokens, give suggestions on how to fix it
- Don't put `NaN` on spans as the exporter refuses to send spans with it
- Hopefully fix release-please

The fundamental issue was the `@ai-sdk/openai` v1 returns `NaN` token count for `streamText` by default

Can be fixed by using strict compatibility mode (which is default in v2)

```
const openai = createOpenAI({
  apiKey: process.env.OPENAI_API_KEY!,
  compatibility: 'strict',
});
```

If you want to review and don't care about the examples that much, these are the files to look at:

```
packages/ai/src/otel/AxiomWrappedLanguageModelV1.ts
examples/example-instrumentation-nextjs-v4/src/shared/openai.ts
.github/workflows/release-ai-sdk.yaml
release-please-config.json
```