### PR TITLE
feat: warn if no tracer found, add jsdoc

### DIFF
--- a/packages/ai/src/otel/initAxiomAI.ts
+++ b/packages/ai/src/otel/initAxiomAI.ts
@@ -1,6 +1,14 @@
 import type { Tracer } from '@opentelemetry/api';
 import { AxiomAIResources } from './shared';
 
+/**
+ * Register this in your `instrumentation.ts` to set up @axiomhq/ai.
+ * This function registers the tracer to enable Context Propagation and Instrumentation Scope.
+ * If you do not register a tracer, some spans may not be linked properly.
+ *
+ * @param config
+ * @param config.tracer - The tracer that you are using in your application.
+ */
 export function initAxiomAI(config: { tracer: Tracer }) {
   AxiomAIResources.getInstance().init(config);
 }


### PR DESCRIPTION
New logic:

1. If a tracer is passed to `withSpan`, use that
2. If `initAxiomAI` was run, use the tracer from that
3. If neither of those exist, log a warning and fall back to a default tracer