### PR TITLE
feat: match more providers

### DIFF
--- a/packages/ai/src/otel/semconv/attributes.ts
+++ b/packages/ai/src/otel/semconv/attributes.ts
@@ -105,6 +105,22 @@ const ATTR_GEN_AI_STEP_NAME = 'gen_ai.step.name';
 const ATTR_GEN_AI_TOOL_ARGUMENTS = 'gen_ai.tool.arguments'; // deprecated by OTel
 const ATTR_GEN_AI_TOOL_MESSAGE = 'gen_ai.tool.message'; // deprecated by OTel
 
+const GEN_AI_PROVIDER_NAME_VALUE_ASSEMBLYAI = 'assemblyai';
+const GEN_AI_PROVIDER_NAME_VALUE_CEREBRAS = 'cerebras';
+const GEN_AI_PROVIDER_NAME_VALUE_DEEPGRAM = 'deepgram';
+const GEN_AI_PROVIDER_NAME_VALUE_DEEPINFRA = 'deepinfra';
+const GEN_AI_PROVIDER_NAME_VALUE_ELEVENLABS = 'elevenlabs';
+const GEN_AI_PROVIDER_NAME_VALUE_FAL = 'fal';
+const GEN_AI_PROVIDER_NAME_VALUE_FIREWORKS = 'fireworks';
+const GEN_AI_PROVIDER_NAME_VALUE_GLADIA = 'gladia';
+const GEN_AI_PROVIDER_NAME_VALUE_HUME = 'hume';
+const GEN_AI_PROVIDER_NAME_VALUE_LMNT = 'lmnt';
+const GEN_AI_PROVIDER_NAME_VALUE_LUMA = 'luma';
+const GEN_AI_PROVIDER_NAME_VALUE_REPLICATE = 'replicate';
+const GEN_AI_PROVIDER_NAME_VALUE_REVAI = 'revai';
+const GEN_AI_PROVIDER_NAME_VALUE_TOGETHERAI = 'togetherai';
+const GEN_AI_PROVIDER_NAME_VALUE_VERCEL = 'vercel';
+
 /**
  * When adding something new here, please:
  * 1. Make sure it doesn't already exist as part of OTel Semantic Conventions (use that instead)
@@ -147,19 +163,34 @@ export const Attr = {
       Name_Values: {
         // TODO: these will be replaced with GEN_AI_PROVIDER_NAME_VALUE_<provider> or similar once the new version of the semconv package ships
         Anthropic: GEN_AI_SYSTEM_VALUE_ANTHROPIC,
+        AssemblyAI: GEN_AI_PROVIDER_NAME_VALUE_ASSEMBLYAI,
         AWSBedrock: GEN_AI_SYSTEM_VALUE_AWS_BEDROCK,
         AzureAIInference: GEN_AI_SYSTEM_VALUE_AZURE_AI_INFERENCE,
         AzureAIOpenAI: GEN_AI_SYSTEM_VALUE_AZURE_AI_OPENAI,
+        Cerebras: GEN_AI_PROVIDER_NAME_VALUE_CEREBRAS,
         Cohere: GEN_AI_SYSTEM_VALUE_COHERE,
+        Deepgram: GEN_AI_PROVIDER_NAME_VALUE_DEEPGRAM,
+        DeepInfra: GEN_AI_PROVIDER_NAME_VALUE_DEEPINFRA,
         Deepseek: GEN_AI_SYSTEM_VALUE_DEEPSEEK,
+        ElevenLabs: GEN_AI_PROVIDER_NAME_VALUE_ELEVENLABS,
+        Fal: GEN_AI_PROVIDER_NAME_VALUE_FAL,
+        Fireworks: GEN_AI_PROVIDER_NAME_VALUE_FIREWORKS,
         GCPGemini: GEN_AI_SYSTEM_VALUE_GCP_GEMINI,
         GCPGenAI: GEN_AI_SYSTEM_VALUE_GCP_GEN_AI,
         GCPVertexAI: GEN_AI_SYSTEM_VALUE_GCP_VERTEX_AI,
+        Gladia: GEN_AI_PROVIDER_NAME_VALUE_GLADIA,
         Groq: GEN_AI_SYSTEM_VALUE_GROQ,
+        Hume: GEN_AI_PROVIDER_NAME_VALUE_HUME,
         IBMWatsonxAI: GEN_AI_SYSTEM_VALUE_IBM_WATSONX_AI,
+        Lmnt: GEN_AI_PROVIDER_NAME_VALUE_LMNT,
+        Luma: GEN_AI_PROVIDER_NAME_VALUE_LUMA,
         MistralAI: GEN_AI_SYSTEM_VALUE_MISTRAL_AI,
         OpenAI: GEN_AI_SYSTEM_VALUE_OPENAI,
         Perplexity: GEN_AI_SYSTEM_VALUE_PERPLEXITY,
+        Replicate: GEN_AI_PROVIDER_NAME_VALUE_REPLICATE,
+        RevAI: GEN_AI_PROVIDER_NAME_VALUE_REVAI,
+        TogetherAI: GEN_AI_PROVIDER_NAME_VALUE_TOGETHERAI,
+        Vercel: GEN_AI_PROVIDER_NAME_VALUE_VERCEL,
         XAI: GEN_AI_SYSTEM_VALUE_XAI,
       },
     },

--- a/packages/ai/src/otel/utils/wrapperUtils.ts
+++ b/packages/ai/src/otel/utils/wrapperUtils.ts
@@ -537,10 +537,21 @@ export function mapProviderToSystem(provider: string): string | undefined {
     case 'amazon-bedrock':
       return Attr.GenAI.Provider.Name_Values.AWSBedrock;
     case 'anthropic':
+    case 'anthropic.messages':
       return Attr.GenAI.Provider.Name_Values.Anthropic;
+    case 'assemblyai':
+    case 'assemblyai.transcription':
+      return Attr.GenAI.Provider.Name_Values.AssemblyAI;
+    case 'deepgram':
+    case 'deepgram.transcription':
+      return Attr.GenAI.Provider.Name_Values.Deepgram;
     case 'gateway':
       return OTHER_VALUE;
+    case 'gladia':
+    case 'gladia.transcription':
+      return Attr.GenAI.Provider.Name_Values.Gladia;
     case 'google':
+    case 'google.generative-ai':
       return Attr.GenAI.Provider.Name_Values.GCPGemini;
     case 'groq':
       return Attr.GenAI.Provider.Name_Values.Groq;
@@ -549,22 +560,19 @@ export function mapProviderToSystem(provider: string): string | undefined {
     case 'openai':
       return Attr.GenAI.Provider.Name_Values.OpenAI;
     case 'openai-compatible':
+      // I don't think we want to return something specific here?
       return OTHER_VALUE;
     case 'perplexity':
       return Attr.GenAI.Provider.Name_Values.Perplexity;
     case 'replicate':
-      return OTHER_VALUE;
+      return Attr.GenAI.Provider.Name_Values.Replicate;
+    case 'revai':
+    case 'revai.transcription':
+      return Attr.GenAI.Provider.Name_Values.RevAI;
     case 'togetherai':
-      return OTHER_VALUE;
+      return Attr.GenAI.Provider.Name_Values.TogetherAI;
     case 'xai':
       return Attr.GenAI.Provider.Name_Values.XAI;
-
-    // Specialized providers that should not have system attribute
-    case 'assemblyai':
-    case 'deepgram':
-    case 'gladia':
-    case 'revai':
-      return undefined;
 
     // startswith + fall through
     default: {
@@ -572,40 +580,61 @@ export function mapProviderToSystem(provider: string): string | undefined {
         return Attr.GenAI.Provider.Name_Values.AzureAIOpenAI;
       }
       if (provider.startsWith('cerebras.')) {
-        return OTHER_VALUE;
+        return Attr.GenAI.Provider.Name_Values.Cerebras;
       }
       if (provider.startsWith('cohere.')) {
         return Attr.GenAI.Provider.Name_Values.Cohere;
       }
       if (provider.startsWith('deepinfra.')) {
-        return OTHER_VALUE;
+        return Attr.GenAI.Provider.Name_Values.DeepInfra;
       }
       if (provider.startsWith('deepseek.')) {
         return Attr.GenAI.Provider.Name_Values.Deepseek;
       }
       if (provider.startsWith('elevenlabs.')) {
-        return OTHER_VALUE;
+        return Attr.GenAI.Provider.Name_Values.ElevenLabs;
       }
       if (provider.startsWith('fal.')) {
-        return OTHER_VALUE;
+        return Attr.GenAI.Provider.Name_Values.Fal;
       }
       if (provider.startsWith('fireworks.')) {
-        return OTHER_VALUE;
+        return Attr.GenAI.Provider.Name_Values.Fireworks;
       }
       if (provider.startsWith('google.vertex.')) {
         return Attr.GenAI.Provider.Name_Values.GCPVertexAI;
       }
+      if (provider.startsWith('groq.')) {
+        return Attr.GenAI.Provider.Name_Values.Groq;
+      }
       if (provider.startsWith('hume.')) {
-        return OTHER_VALUE;
+        return Attr.GenAI.Provider.Name_Values.Hume;
       }
       if (provider.startsWith('lmnt.')) {
-        return OTHER_VALUE;
+        return Attr.GenAI.Provider.Name_Values.Lmnt;
       }
       if (provider.startsWith('luma.')) {
-        return OTHER_VALUE;
+        return Attr.GenAI.Provider.Name_Values.Luma;
+      }
+      if (provider.startsWith('mistral.')) {
+        return Attr.GenAI.Provider.Name_Values.MistralAI;
+      }
+      if (provider.startsWith('openai.')) {
+        return Attr.GenAI.Provider.Name_Values.OpenAI;
       }
       if (provider.startsWith('vercel.')) {
-        return OTHER_VALUE;
+        return Attr.GenAI.Provider.Name_Values.Vercel;
+      }
+      if (provider.startsWith('vertex.anthropic.')) {
+        return Attr.GenAI.Provider.Name_Values.Anthropic;
+      }
+      if (provider.startsWith('xai.')) {
+        return Attr.GenAI.Provider.Name_Values.XAI;
+      }
+
+      // most other openai-compatible providers use {providerName}.{chat|completion|embedding|image}
+      const s = provider.split('.');
+      if (s.length === 2) {
+        return s[0];
       }
 
       // For unknown providers, don't set the attribute

--- a/packages/ai/src/otel/utils/wrapperUtils.ts
+++ b/packages/ai/src/otel/utils/wrapperUtils.ts
@@ -532,6 +532,11 @@ export function determineOutputTypeV2(options: {
 export function mapProviderToSystem(provider: string): string | undefined {
   const OTHER_VALUE = '_OTHER';
 
+  if (provider === 'openai-compatible') {
+    // I don't think we want to return something specific here?
+    return OTHER_VALUE;
+  }
+
   // exact matches
   switch (provider) {
     case 'amazon-bedrock':
@@ -559,9 +564,6 @@ export function mapProviderToSystem(provider: string): string | undefined {
       return Attr.GenAI.Provider.Name_Values.MistralAI;
     case 'openai':
       return Attr.GenAI.Provider.Name_Values.OpenAI;
-    case 'openai-compatible':
-      // I don't think we want to return something specific here?
-      return OTHER_VALUE;
     case 'perplexity':
       return Attr.GenAI.Provider.Name_Values.Perplexity;
     case 'replicate':

--- a/packages/ai/src/otel/utils/wrapperUtils.ts
+++ b/packages/ai/src/otel/utils/wrapperUtils.ts
@@ -627,7 +627,7 @@ export function mapProviderToSystem(provider: string): string | undefined {
         return Attr.GenAI.Provider.Name_Values.Vercel;
       }
       if (provider.startsWith('vertex.anthropic.')) {
-        return Attr.GenAI.Provider.Name_Values.Anthropic;
+        return Attr.GenAI.Provider.Name_Values.GCPVertexAI;
       }
       if (provider.startsWith('xai.')) {
         return Attr.GenAI.Provider.Name_Values.XAI;

--- a/packages/ai/src/otel/utils/wrapperUtils.ts
+++ b/packages/ai/src/otel/utils/wrapperUtils.ts
@@ -234,7 +234,7 @@ export function setBaseAttributes(span: Span, provider: string, modelId: string)
     [Attr.GenAI.Request.Model]: modelId,
   });
 
-  const systemValue = mapProviderToSystem(provider);
+  const systemValue = mapVercelSDKProviderToOTelProvider(provider);
   if (systemValue) {
     span.setAttribute(Attr.GenAI.Provider.Name, systemValue);
   }
@@ -524,21 +524,19 @@ export function determineOutputTypeV2(options: {
 }
 
 /**
- * Maps AI SDK provider IDs to OpenTelemetry gen_ai.system values
+ * Maps AI SDK provider IDs to OpenTelemetry gen_ai.provider.name values
  *
- * @param provider - The provider ID from the AI SDK
- * @returns The corresponding system value or '_OTHER' for unmapped providers, undefined for providers that shouldn't be mapped
+ * @param vercelSDKProvider - The provider ID from the AI SDK
+ * @returns The corresponding `gen_ai.provider.name` value, or `undefined` if no match is found
  */
-export function mapProviderToSystem(provider: string): string | undefined {
-  const OTHER_VALUE = '_OTHER';
-
-  if (provider === 'openai-compatible') {
-    // I don't think we want to return something specific here?
-    return OTHER_VALUE;
+export function mapVercelSDKProviderToOTelProvider(vercelSDKProvider: string): string | undefined {
+  if (vercelSDKProvider === 'openai-compatible') {
+    // we don't know the real provider
+    return undefined;
   }
 
   // exact matches
-  switch (provider) {
+  switch (vercelSDKProvider) {
     case 'amazon-bedrock':
       return Attr.GenAI.Provider.Name_Values.AWSBedrock;
     case 'anthropic':
@@ -550,8 +548,6 @@ export function mapProviderToSystem(provider: string): string | undefined {
     case 'deepgram':
     case 'deepgram.transcription':
       return Attr.GenAI.Provider.Name_Values.Deepgram;
-    case 'gateway':
-      return OTHER_VALUE;
     case 'gladia':
     case 'gladia.transcription':
       return Attr.GenAI.Provider.Name_Values.Gladia;
@@ -578,63 +574,63 @@ export function mapProviderToSystem(provider: string): string | undefined {
 
     // startswith + fall through
     default: {
-      if (provider.startsWith('azure.')) {
+      if (vercelSDKProvider.startsWith('azure.')) {
         return Attr.GenAI.Provider.Name_Values.AzureAIOpenAI;
       }
-      if (provider.startsWith('cerebras.')) {
+      if (vercelSDKProvider.startsWith('cerebras.')) {
         return Attr.GenAI.Provider.Name_Values.Cerebras;
       }
-      if (provider.startsWith('cohere.')) {
+      if (vercelSDKProvider.startsWith('cohere.')) {
         return Attr.GenAI.Provider.Name_Values.Cohere;
       }
-      if (provider.startsWith('deepinfra.')) {
+      if (vercelSDKProvider.startsWith('deepinfra.')) {
         return Attr.GenAI.Provider.Name_Values.DeepInfra;
       }
-      if (provider.startsWith('deepseek.')) {
+      if (vercelSDKProvider.startsWith('deepseek.')) {
         return Attr.GenAI.Provider.Name_Values.Deepseek;
       }
-      if (provider.startsWith('elevenlabs.')) {
+      if (vercelSDKProvider.startsWith('elevenlabs.')) {
         return Attr.GenAI.Provider.Name_Values.ElevenLabs;
       }
-      if (provider.startsWith('fal.')) {
+      if (vercelSDKProvider.startsWith('fal.')) {
         return Attr.GenAI.Provider.Name_Values.Fal;
       }
-      if (provider.startsWith('fireworks.')) {
+      if (vercelSDKProvider.startsWith('fireworks.')) {
         return Attr.GenAI.Provider.Name_Values.Fireworks;
       }
-      if (provider.startsWith('google.vertex.')) {
+      if (vercelSDKProvider.startsWith('google.vertex.')) {
         return Attr.GenAI.Provider.Name_Values.GCPVertexAI;
       }
-      if (provider.startsWith('groq.')) {
+      if (vercelSDKProvider.startsWith('groq.')) {
         return Attr.GenAI.Provider.Name_Values.Groq;
       }
-      if (provider.startsWith('hume.')) {
+      if (vercelSDKProvider.startsWith('hume.')) {
         return Attr.GenAI.Provider.Name_Values.Hume;
       }
-      if (provider.startsWith('lmnt.')) {
+      if (vercelSDKProvider.startsWith('lmnt.')) {
         return Attr.GenAI.Provider.Name_Values.Lmnt;
       }
-      if (provider.startsWith('luma.')) {
+      if (vercelSDKProvider.startsWith('luma.')) {
         return Attr.GenAI.Provider.Name_Values.Luma;
       }
-      if (provider.startsWith('mistral.')) {
+      if (vercelSDKProvider.startsWith('mistral.')) {
         return Attr.GenAI.Provider.Name_Values.MistralAI;
       }
-      if (provider.startsWith('openai.')) {
+      if (vercelSDKProvider.startsWith('openai.')) {
         return Attr.GenAI.Provider.Name_Values.OpenAI;
       }
-      if (provider.startsWith('vercel.')) {
+      if (vercelSDKProvider.startsWith('vercel.')) {
         return Attr.GenAI.Provider.Name_Values.Vercel;
       }
-      if (provider.startsWith('vertex.anthropic.')) {
+      if (vercelSDKProvider.startsWith('vertex.anthropic.')) {
         return Attr.GenAI.Provider.Name_Values.GCPVertexAI;
       }
-      if (provider.startsWith('xai.')) {
+      if (vercelSDKProvider.startsWith('xai.')) {
         return Attr.GenAI.Provider.Name_Values.XAI;
       }
 
       // most other openai-compatible providers use {providerName}.{chat|completion|embedding|image}
-      const s = provider.split('.');
+      const s = vercelSDKProvider.split('.');
       if (s.length === 2) {
         return s[0];
       }

--- a/packages/ai/test/vercel/attributes.test.ts
+++ b/packages/ai/test/vercel/attributes.test.ts
@@ -61,6 +61,7 @@ describe('span names', () => {
       'gen_ai.output.messages': '[{"role":"assistant","content":"Mock response"}]',
       'gen_ai.response.finish_reasons': '["stop"]',
       'gen_ai.operation.name': 'chat',
+      'gen_ai.provider.name': 'mock',
       'gen_ai.capability.name': 'test-capability',
       'gen_ai.step.name': 'test-step',
       'gen_ai.output.type': 'text',

--- a/packages/ai/test/vercel/mock-provider-v1/mock-provider.ts
+++ b/packages/ai/test/vercel/mock-provider-v1/mock-provider.ts
@@ -85,7 +85,7 @@ export class MockProvider implements ProviderV1 {
 
   constructor(config: MockProviderConfig = {}) {
     this.config = {
-      providerId: 'mock-provider',
+      providerId: 'mock.completion',
       defaultDelay: 0,
       throwOnMissingResponse: false,
       ...config,

--- a/packages/ai/test/vercel/mock-provider-v2/mock-provider-v2.ts
+++ b/packages/ai/test/vercel/mock-provider-v2/mock-provider-v2.ts
@@ -95,7 +95,7 @@ export class MockProvider implements ProviderV2 {
 
   constructor(config: MockProviderConfig = {}) {
     this.config = {
-      providerId: 'mock-provider',
+      providerId: 'mock.completion',
       defaultDelay: 0,
       throwOnMissingResponse: false,
       warnOnInfiniteRepeat: true,

--- a/packages/ai/test/vercel/tools-v1.test.ts
+++ b/packages/ai/test/vercel/tools-v1.test.ts
@@ -161,6 +161,7 @@ describe('tool call attributes', () => {
       ]),
       'gen_ai.operation.name': 'chat',
       'gen_ai.output.type': 'text',
+      'gen_ai.provider.name': 'mock',
       'gen_ai.response.finish_reasons': '["stop"]',
       'gen_ai.request.model': 'tool-model',
       'gen_ai.request.temperature': 0,

--- a/packages/ai/test/vercel/tools-v2.test.ts
+++ b/packages/ai/test/vercel/tools-v2.test.ts
@@ -161,6 +161,7 @@ describe('tool call attributes', () => {
         },
       ]),
       'gen_ai.operation.name': 'chat',
+      'gen_ai.provider.name': 'mock',
       'gen_ai.response.finish_reasons': '["tool-calls"]',
       'gen_ai.request.model': 'tool-model',
       'gen_ai.response.id': 'mock-response-id',


### PR DESCRIPTION
There were two issues with provider detection in the SDK until now:
1. The common providers had some name permutations that we didn't know about
2. We didn't add custom names for the providers that do not have default values in semconv, even though semconv allows for custom values. I believe we **SHOULD** cover every possible provider to the best of our ability.

Therefore, this PR adds:
- openai variants such as `openai.embedding`
- `anthropic.messages`
- a bunch of new providers: assemblyai, cerebras, deepgram, deepinfra, elevenlabs, fal, fireworks, gladia, hume, lmnt, luma, replicate, revai, togetherai, vercel

One intentional omission that we are not covering for now is `openai-compatible`. Need to confirm with the semconv people whether that should be the name, or if it's better to omit it (because it could be any number of providers!)

Mock providers have been updated to get their names detected by the `<provider>.<action>` case, and tests have been updated accordingly.