### PR TITLE
feat: put capability and step name on tool calls

### DIFF
--- a/packages/ai/src/otel/wrapTool.ts
+++ b/packages/ai/src/otel/wrapTool.ts
@@ -4,7 +4,7 @@ import { type Tool as ToolV5 } from 'aiv5';
 import { createStartActiveSpan } from './startActiveSpan';
 import { Attr } from './semconv/attributes';
 import { typedEntries } from '../util/typedEntries';
-import { setAxiomBaseAttributes, getTracer, classifyToolError } from './utils/wrapperUtils';
+import { setAxiomBaseAttributes, getTracer, classifyToolError, setScopeAttributes } from './utils/wrapperUtils';
 import { getRedactionPolicy, handleMaybeRedactedAttribute } from './utils/redaction';
 
 type Tool = ToolV4 | ToolV5;
@@ -52,6 +52,9 @@ export function wrapTool<T extends ToolLike>(toolName: string, tool: T): T {
 
         // Set Axiom base attributes
         setAxiomBaseAttributes(span);
+        
+        // Set capability/step attributes from baggage
+        setScopeAttributes(span);
 
         // Handle different opts structures between AI SDK versions
         const toolCallId =

--- a/packages/ai/src/otel/wrapTool.ts
+++ b/packages/ai/src/otel/wrapTool.ts
@@ -4,7 +4,12 @@ import { type Tool as ToolV5 } from 'aiv5';
 import { createStartActiveSpan } from './startActiveSpan';
 import { Attr } from './semconv/attributes';
 import { typedEntries } from '../util/typedEntries';
-import { setAxiomBaseAttributes, getTracer, classifyToolError, setScopeAttributes } from './utils/wrapperUtils';
+import {
+  setAxiomBaseAttributes,
+  getTracer,
+  classifyToolError,
+  setScopeAttributes,
+} from './utils/wrapperUtils';
 import { getRedactionPolicy, handleMaybeRedactedAttribute } from './utils/redaction';
 
 type Tool = ToolV4 | ToolV5;
@@ -50,10 +55,7 @@ export function wrapTool<T extends ToolLike>(toolName: string, tool: T): T {
       return startActiveSpan(spanName, null, async (span: Span) => {
         const redactionPolicy = getRedactionPolicy();
 
-        // Set Axiom base attributes
         setAxiomBaseAttributes(span);
-        
-        // Set capability/step attributes from baggage
         setScopeAttributes(span);
 
         // Handle different opts structures between AI SDK versions

--- a/packages/ai/test/vercel/tools-v1.test.ts
+++ b/packages/ai/test/vercel/tools-v1.test.ts
@@ -106,6 +106,8 @@ describe('tool call attributes', () => {
       'axiom.gen_ai.schema_url': 'https://axiom.co/ai/schemas/0.0.2',
       'axiom.gen_ai.sdk.name': 'axiom',
       'axiom.gen_ai.sdk.version': packageJson.version,
+      'gen_ai.capability.name': 'test-capability',
+      'gen_ai.step.name': 'test-step',
       'gen_ai.operation.name': 'execute_tool',
       'gen_ai.tool.call.id': 'call-456',
       'gen_ai.tool.description': 'Search through a database',

--- a/packages/ai/test/vercel/tools-v2.test.ts
+++ b/packages/ai/test/vercel/tools-v2.test.ts
@@ -107,6 +107,8 @@ describe('tool call attributes', () => {
       'axiom.gen_ai.schema_url': 'https://axiom.co/ai/schemas/0.0.2',
       'axiom.gen_ai.sdk.name': 'axiom',
       'axiom.gen_ai.sdk.version': packageJson.version,
+      'gen_ai.capability.name': 'test-capability',
+      'gen_ai.step.name': 'test-step',
       'gen_ai.operation.name': 'execute_tool',
       'gen_ai.tool.call.id': 'call-456',
       'gen_ai.tool.description': 'Search through a database',


### PR DESCRIPTION
## Context

- This makes it easier to find tool calls that relate to specific features etc
- I don't think there is a real downside as we can still filter on `gen_ai.operation.name`