### PR TITLE
chore: bump pnpm, add minimumReleaseAge

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ on:
       - main
 
 env:
-  PNPM_VERSION: 10.11.1
+  PNPM_VERSION: 10.16.1
   NODE_VERSION: 22
 
 jobs:

--- a/.github/workflows/release-on-tag.yaml
+++ b/.github/workflows/release-on-tag.yaml
@@ -5,7 +5,7 @@ on:
       - axiom-v*
 
 env:
-  PNPM_VERSION: 10.11.1
+  PNPM_VERSION: 10.16.1
   NODE_VERSION: 22
 
 

--- a/package.json
+++ b/package.json
@@ -15,5 +15,5 @@
     "prettier": "catalog:",
     "turbo": "^2.5.4"
   },
-  "packageManager": "pnpm@10.11.1"
+  "packageManager": "pnpm@10.16.1"
 }

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -107,5 +107,5 @@
   "files": [
     "dist"
   ],
-  "packageManager": "pnpm@10.11.1"
+  "packageManager": "pnpm@10.16.1"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,3 +11,4 @@ catalog:
   vitest: ^3.2.1
   vite-plugin-dts: ^4.5.4
   tsup: ^8.3.5
+minimumReleaseAge: 1440


### PR DESCRIPTION
After a series of npm supply chain attacks, pnpm added `minimumReleaseAge`, which will not install packages newer than this threshold. This PR updates pnpm, and adds a minimum release age of 1 day.