### PR TITLE
feat: allow glob and eval name matching

### DIFF
--- a/examples/example-evals-nextjs/package.json
+++ b/examples/example-evals-nextjs/package.json
@@ -11,7 +11,9 @@
     "lint": "eslint './**/*.{js,ts}'",
     "typecheck": "tsc --noEmit",
     "eval": "axiom eval .",
-    "eval:ticket-classification": "axiom eval src/lib/capabilities/classify-ticket/evaluations/ticket-classification.eval.ts"
+    "eval:by-file": "axiom eval src/lib/capabilities/classify-ticket/evaluations/ticket-classification.eval.ts",
+    "eval:by-glob": "axiom eval **/ticket*.ts",
+    "eval:by-name": "axiom eval \"Spam\""
   },
   "dependencies": {
     "@ai-sdk/openai": "2.0.0-beta.11",

--- a/packages/ai/src/cli/commands/eval.command.ts
+++ b/packages/ai/src/cli/commands/eval.command.ts
@@ -3,13 +3,14 @@ import { runVitest } from '../../evals/run-vitest';
 import { lstatSync } from 'node:fs';
 import { runEvalWithContext } from '../utils/eval-context-runner';
 import type { FlagOverrides } from '../utils/parse-flag-overrides';
+import { isGlob } from '../utils/glob-utils';
 
 export const loadEvalCommand = (program: Command, flagOverrides: FlagOverrides = {}) => {
   return program.addCommand(
     new Command('eval')
       .description('run evals locally')
       .addArgument(
-        new Argument('[path]', 'path of base directory or *.eval.ts file').default(
+        new Argument('[target]', 'file, directory, glob pattern, or eval name').default(
           '.',
           'any *.eval.ts file in current directory',
         ),
@@ -19,21 +20,43 @@ export const loadEvalCommand = (program: Command, flagOverrides: FlagOverrides =
       .option('-d, --dataset <DATASET>', 'axiom dataset name', process.env.AXIOM_DATASET)
       .option('-u, --url <AXIOM URL>', 'axiom url', process.env.AXIOM_URL ?? 'https://api.axiom.co')
       .option('-b, --baseline <BASELINE ID>', 'id of baseline evaluation to compare against')
-      .action(async (path: string, options) => {
+      .action(async (target: string, options) => {
         if (!options.token || !options.dataset) {
           throw new Error('AXIOM_TOKEN, and AXIOM_DATASET must be set');
         }
 
-        const f = lstatSync(path);
-        const isDir = f.isDirectory();
-        const targetPath = isDir ? path : '.';
-        const includedfiles = isDir ? ['**/*.eval.ts'] : [path];
+        let targetPath = '.';
+        let include = ['**/*.eval.ts'];
+        let testNamePattern: RegExp | undefined;
+
+        const isGlobPattern = isGlob(target);
+        
+        if (isGlobPattern) {
+          // Handle glob patterns like "**/*.eval.ts" or "**/my-feature/*"
+          include = [target];
+        } else {
+          try {
+            // Try to treat as file/directory path
+            const stat = lstatSync(target);
+            if (stat.isDirectory()) {
+              targetPath = target;
+              include = ['**/*.eval.ts'];
+            } else {
+              // Single file
+              include = [target];
+            }
+          } catch {
+            // Path doesn't exist, treat as eval name
+            testNamePattern = new RegExp(target, 'i');
+          }
+        }
 
         await runEvalWithContext(flagOverrides, async () => {
           return runVitest(targetPath, {
             watch: options.watch,
             baseline: options.baseline,
-            include: includedfiles,
+            include,
+            testNamePattern,
           });
         });
       }),

--- a/packages/ai/src/cli/utils/glob-utils.ts
+++ b/packages/ai/src/cli/utils/glob-utils.ts
@@ -1,0 +1,8 @@
+/**
+ * Simple glob detection utility
+ * Detects if a string contains glob pattern characters
+ */
+export function isGlob(str: string): boolean {
+  // Check for glob characters: * ? [ ] { } !
+  return /[*?[\]{}!]/.test(str);
+}

--- a/packages/ai/src/evals/run-vitest.ts
+++ b/packages/ai/src/evals/run-vitest.ts
@@ -10,12 +10,14 @@ export const runVitest = async (
     watch: boolean;
     baseline?: string;
     include: string[];
+    testNamePattern?: RegExp;
   },
 ) => {
   const vi = await createVitest('test', {
     root: dir ? dir : process.cwd(),
     mode: 'test',
     include: opts.include,
+    testNamePattern: opts.testNamePattern,
     reporters: ['verbose', new AxiomReporter()],
     environment: 'node',
     browser: undefined,


### PR DESCRIPTION
BEFORE MERGE: CHANGE TARGET TO MAIN (i'm targeting the branch i'm stacking on top of for now)

## Context

Currently we allow `axiom eval` to run all evals and `axiom eval some/dir/filename.ts` to run one file

This adds support for glob patterns and eval name matching. Name matching works the same way as in regular vitest, ie partial and case insensitive.

```
# glob pattern examples
axiom eval **/dir/*.ts
axiom eval **/*-new*

# name matching examples
axiom eval "spam"
```