### PR TITLE
fix: race condition in runner

### DIFF
--- a/packages/ai/src/evals/instrument.ts
+++ b/packages/ai/src/evals/instrument.ts
@@ -2,7 +2,7 @@ import { BatchSpanProcessor, NodeTracerProvider } from '@opentelemetry/sdk-trace
 import { resourceFromAttributes } from '@opentelemetry/resources';
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
 import { trace, type Context, type SpanOptions } from '@opentelemetry/api';
-import { initAxiomAI } from 'src/otel/initAxiomAI';
+import { initAxiomAI } from '../otel/initAxiomAI';
 
 const collectorOptions = {
   url: process.env.AXIOM_URL


### PR DESCRIPTION
## Before:

<img width="478" height="209" alt="image" src="https://github.com/user-attachments/assets/f05e3eff-ef56-4095-8af0-7789a82339d6" />

## After:

This no longer happens

## Context

Why it happened:
- Reporter expected `meta.evaluation` to exist in `onTestSuiteReady`
- But `meta.evaluation` was only set in `beforeAll` hook
- `beforeAll` runs **after** `onTestSuiteReady` 

