### PR TITLE
fix: FallbackManager being used in ESM

### DIFF
--- a/packages/ai/src/evals/context/manager.ts
+++ b/packages/ai/src/evals/context/manager.ts
@@ -45,7 +45,7 @@ function getContextManager(): ContextManager {
     }
   } else {
     // Browser/CF Workers - simple fallback (no warning needed here)
-    console.warn('AsyncLocalStorage not available, using fallback context manager:');
+    console.warn('AsyncLocalStorage not available, using fallback context manager');
     manager = createFallbackManager();
   }
 

--- a/packages/ai/src/evals/context/manager.ts
+++ b/packages/ai/src/evals/context/manager.ts
@@ -1,3 +1,5 @@
+import { createRequire } from 'node:module';
+
 interface ContextManager<T = any> {
   getStore(): T | undefined;
   run<R>(value: T, fn: () => R): R;
@@ -13,47 +15,37 @@ function setGlobalContextManager(manager: ContextManager): void {
   (globalThis as any)[CONTEXT_MANAGER_SYMBOL] = manager;
 }
 
-const isNodeJS = typeof process !== 'undefined' && process.versions && process.versions.node;
+const isNodeJS = typeof process !== 'undefined' && !!process.versions?.node;
 
 function getContextManager(): ContextManager {
   // Check global Symbol registry cache first (shared across VM contexts)
   const existing = getGlobalContextManager();
-  if (existing) {
-    return existing;
-  }
+  if (existing) return existing;
 
   let manager: ContextManager;
 
   if (isNodeJS) {
     try {
-      // Try dynamic require approaches to work in both Node.js and bundled environments
-      let AsyncLocalStorage;
+      // Resolve AsyncLocalStorage in both ESM and CJS Node contexts without bundler interference
+      let AsyncLocalStorage: any;
 
+      // Use createRequire to obtain a require in ESM
+      const req = createRequire(import.meta.url);
       try {
-        // Try direct require first (works in most Node.js contexts)
-        const requireFn = eval('require');
-        AsyncLocalStorage = requireFn('async_hooks').AsyncLocalStorage;
-      } catch (directError) {
-        try {
-          // Fallback: createRequire approach (works in VM contexts like Vitest)
-          const requireFn = eval('require');
-          const { createRequire } = requireFn('module');
-          const dynamicRequire = createRequire(import.meta.url);
-          AsyncLocalStorage = dynamicRequire('async_hooks').AsyncLocalStorage;
-        } catch (_createRequireError) {
-          // If both approaches fail, re-throw the original error for better debugging
-          throw directError;
-        }
+        AsyncLocalStorage = req('node:async_hooks').AsyncLocalStorage;
+      } catch {
+        AsyncLocalStorage = req('async_hooks').AsyncLocalStorage;
       }
 
       manager = new AsyncLocalStorage();
     } catch (error) {
-      // Fallback if async_hooks is not available
+      // Fallback if AsyncLocalStorage cannot be loaded
       console.warn('AsyncLocalStorage not available, using fallback context manager:', error);
       manager = createFallbackManager();
     }
   } else {
     // Browser/CF Workers - simple fallback (no warning needed here)
+    console.warn('AsyncLocalStorage not available, using fallback context manager:');
     manager = createFallbackManager();
   }
 

--- a/packages/ai/tsup.config.ts
+++ b/packages/ai/tsup.config.ts
@@ -11,6 +11,11 @@ export default defineConfig({
     'vitest/index.cjs',
     'esbuild',
     'fsevents',
+    // Ensure Node builtins used via createRequire stay external in ESM bundle
+    'async_hooks',
+    'node:async_hooks',
+    'module',
+    'node:module',
   ], // don't bundle these
   noExternal: ['handlebars'],
   dts: true, // generate .d.ts files


### PR DESCRIPTION
Eval context attempts to use AsyncLocalStorage, and falls back to a (less reliable) FallbackManager when that is not available.

Before this PR, we were falling back more often than we need to. Most importantly, we were falling back in _every_ ESM use case.

This fixes that. It also improves our build as we no longer get the warnings about `require`/`eval`