### PR TITLE
feat: `gen_ai.provider.name` for ai gateway

### DIFF
--- a/packages/ai/src/otel/utils/wrapperUtils.ts
+++ b/packages/ai/src/otel/utils/wrapperUtils.ts
@@ -548,6 +548,8 @@ export function mapVercelSDKProviderToOTelProvider(vercelSDKProvider: string): s
     case 'deepgram':
     case 'deepgram.transcription':
       return Attr.GenAI.Provider.Name_Values.Deepgram;
+    case 'gateway': // `import { gateway } from 'ai'`
+      return Attr.GenAI.Provider.Name_Values.Vercel;
     case 'gladia':
     case 'gladia.transcription':
       return Attr.GenAI.Provider.Name_Values.Gladia;


### PR DESCRIPTION
Vercel AI Gateway did not yet exist as a provider when I built the mappings

Context: https://x.com/Sandeepg33k/status/1971131777646571840