### PR TITLE
feat: debug mode

### DIFF
--- a/examples/example-evals-nextjs/package.json
+++ b/examples/example-evals-nextjs/package.json
@@ -10,7 +10,7 @@
     "format:check": "prettier --check .",
     "lint": "eslint './**/*.{js,ts}'",
     "typecheck": "tsc --noEmit",
-    "eval": "axiom eval .",
+    "eval": "node ../../packages/ai/dist/bin.js eval .",
     "eval:by-file": "axiom eval src/lib/capabilities/classify-ticket/evaluations/ticket-classification.eval.ts",
     "eval:by-glob": "axiom eval **/ticket*.ts",
     "eval:by-name": "axiom eval \"Spam\""

--- a/examples/example-evals-nextjs/src/lib/capabilities/classify-ticket/prompts.ts
+++ b/examples/example-evals-nextjs/src/lib/capabilities/classify-ticket/prompts.ts
@@ -51,9 +51,7 @@ export const classifyTicketStep = async ({
     context: { subject, content },
   });
 
-  const model = flag('ticketClassification.model', 'gpt-4o-mini');
-  const policy = flag('handleReturnRequest.policy', 'auto-approve');
-  console.log('policy:', policy);
+  const model = flag('ticketClassification.model', 'gpt-5-nano');
 
   const result = await withSpan(
     { capability: 'classify-ticket', step: 'classification' },

--- a/examples/example-evals-nextjs/test/feature.eval.ts
+++ b/examples/example-evals-nextjs/test/feature.eval.ts
@@ -2,7 +2,7 @@ import { experimental_Eval as Eval } from 'axiom/ai/evals';
 import { flag, fact, pickFlags } from '../src/lib/app-scope';
 
 const myFn = async (input: string, expected: string) => {
-  const strategy = flag('behavior.strategy');
+  const strategy = flag('behavior.strategy', 'smart');
 
   const response = strategy === 'dumb' ? input : expected;
 
@@ -20,7 +20,7 @@ const exactMatchScorer = ({ output, expected }: { output: string; expected?: str
 };
 
 Eval('feature-example', {
-  configFlags: pickFlags(['ui']),
+  configFlags: pickFlags('behavior'),
   data: () => [
     {
       input: "['nginx-access-logs'] | where status >= 500",

--- a/examples/example-evals-nextjs/test/feature.eval.ts
+++ b/examples/example-evals-nextjs/test/feature.eval.ts
@@ -26,6 +26,10 @@ Eval('feature-example', {
       input: "['nginx-access-logs'] | where status >= 500",
       expected: 'Nginx 5xx Errors',
     },
+    {
+      input: 'foo',
+      expected: 'bar',
+    },
   ],
   task: async ({ input, expected }) => {
     const r = await myFn(input, expected);

--- a/packages/ai/src/app-scope.ts
+++ b/packages/ai/src/app-scope.ts
@@ -295,7 +295,6 @@ export interface AppScope<
   overrideFlags: OverrideFlagsFunction<FS>;
   withFlags: WithFlagsFunction<FS>;
   pickFlags: PickFlagsFunction<FS>;
-  /** Return a dot-path map of all schema default flags */
   getAllDefaultFlags: () => Record<string, any>;
 }
 

--- a/packages/ai/src/cli/commands/eval.command.ts
+++ b/packages/ai/src/cli/commands/eval.command.ts
@@ -64,6 +64,7 @@ export const loadEvalCommand = (program: Command, flagOverrides: FlagOverrides =
             include,
             testNamePattern,
             debug: options.debug,
+            overrides: flagOverrides,
           });
         });
       }),

--- a/packages/ai/src/cli/commands/eval.command.ts
+++ b/packages/ai/src/cli/commands/eval.command.ts
@@ -26,6 +26,11 @@ export const loadEvalCommand = (program: Command, flagOverrides: FlagOverrides =
           throw new Error('AXIOM_TOKEN, and AXIOM_DATASET must be set');
         }
 
+        // Propagate debug mode to processes that we can't reach otherwise (e.g., reporter, app instrumentation)
+        if (options.debug) {
+          process.env.AXIOM_DEBUG = 'true';
+        }
+
         let targetPath = '.';
         let include = ['**/*.eval.ts'];
         let testNamePattern: RegExp | undefined;

--- a/packages/ai/src/cli/commands/eval.command.ts
+++ b/packages/ai/src/cli/commands/eval.command.ts
@@ -20,8 +20,9 @@ export const loadEvalCommand = (program: Command, flagOverrides: FlagOverrides =
       .option('-d, --dataset <DATASET>', 'axiom dataset name', process.env.AXIOM_DATASET)
       .option('-u, --url <AXIOM URL>', 'axiom url', process.env.AXIOM_URL ?? 'https://api.axiom.co')
       .option('-b, --baseline <BASELINE ID>', 'id of baseline evaluation to compare against')
+      .option('--debug', 'run locally without sending to Axiom or loading baselines', false)
       .action(async (target: string, options) => {
-        if (!options.token || !options.dataset) {
+        if (!options.debug && (!options.token || !options.dataset)) {
           throw new Error('AXIOM_TOKEN, and AXIOM_DATASET must be set');
         }
 
@@ -57,6 +58,7 @@ export const loadEvalCommand = (program: Command, flagOverrides: FlagOverrides =
             baseline: options.baseline,
             include,
             testNamePattern,
+            debug: options.debug,
           });
         });
       }),

--- a/packages/ai/src/cli/utils/eval-context-runner.ts
+++ b/packages/ai/src/cli/utils/eval-context-runner.ts
@@ -17,6 +17,7 @@ export async function runEvalWithContext<T>(
   setGlobalFlagOverrides(overrides);
 
   return withEvalContext({ initialFlags: overrides }, async () => {
+    // TODO: is this necessary? given the `setGlobalFlagOverrides` call above?
     if (Object.keys(overrides).length > 0) {
       overrideFlags(overrides);
     }

--- a/packages/ai/src/evals.ts
+++ b/packages/ai/src/evals.ts
@@ -17,4 +17,4 @@ export { validateCliFlags } from './validate-flags';
 export { type Score } from './evals/scorers';
 export { createScorer as Scorer } from './evals/scorer.factory';
 
-export type { Evaluation, Case, Chat, Task } from './evals/eval.service';
+export type { Evaluation, Case, Chat, Task } from './evals/eval.types';

--- a/packages/ai/src/evals/eval.service.ts
+++ b/packages/ai/src/evals/eval.service.ts
@@ -1,86 +1,11 @@
+import type { Case, Chat, Evaluation, Task } from './eval.types';
+
 const getEnvVars = () => {
   return {
     datasetName: process.env.AXIOM_DATASET ?? '',
     url: process.env.AXIOM_URL ?? 'https://api.axiom.co',
     token: process.env.AXIOM_TOKEN,
   };
-};
-
-export type Evaluation = {
-  id: string;
-  name: string;
-  type: string;
-  version: string;
-  baseline: {
-    id: string | undefined;
-    name: string | undefined;
-  };
-  collection: {
-    name: string;
-    size: number;
-  };
-  prompt: {
-    model: string;
-    params: Record<string, unknown>;
-  };
-  duration: number;
-  status: string;
-  traceId: string;
-  runAt: string;
-  tags: string[];
-  user: {
-    name: string | undefined;
-    email: string | undefined;
-  };
-  cases: Case[];
-};
-
-export type Case = {
-  index: number;
-  input: string;
-  output: string;
-  expected: string;
-  duration: string;
-  status: string;
-  scores: Record<
-    string,
-    {
-      name: string;
-      value: number;
-      metadata: Record<string, any>;
-    }
-  >;
-  runAt: string;
-  spanId: string;
-  traceId: string;
-  task?: Task;
-};
-
-export type Chat = {
-  operation: string;
-  capability: string;
-  step: string;
-  request: {
-    max_token: string;
-    model: string;
-    temperature: number;
-  };
-  response: {
-    finish_reasons: string;
-  };
-  usage: {
-    input_tokens: number;
-    output_tokens: number;
-  };
-};
-
-export type Task = {
-  name: string;
-  output: string;
-  trial: number;
-  type: string;
-  error?: string;
-  chat: Chat;
 };
 
 /** Query axiom to find a baseline for en Eval */

--- a/packages/ai/src/evals/eval.ts
+++ b/packages/ai/src/evals/eval.ts
@@ -22,6 +22,7 @@ declare module 'vitest' {
   }
   export interface ProvidedContext {
     baseline?: string;
+    debug?: boolean;
   }
 }
 
@@ -106,15 +107,19 @@ async function registerEval<
 
   // check if user passed a specific baseline id to the CLI
   const baselineId = inject('baseline');
+  const isDebug = inject('debug');
 
   const result = await describe(
     `evaluate: ${evalName}`,
     async () => {
       const dataset = await datasetPromise;
-      // if user passed a baseline id, if not, find the latest evaluation and use it as a baseline
-      const baseline = baselineId
-        ? await findEvaluationCases(baselineId)
-        : await findBaseline(evalName);
+      // use CLI-provided baseline id or find latest
+      // unless in debug mode
+      const baseline = isDebug
+        ? undefined
+        : baselineId
+          ? await findEvaluationCases(baselineId)
+          : await findBaseline(evalName);
       // create a version code
       const evalVersion = nanoid();
       let evalId = ''; // get traceId

--- a/packages/ai/src/evals/eval.ts
+++ b/packages/ai/src/evals/eval.ts
@@ -31,11 +31,11 @@ declare module 'vitest' {
     evaluation: EvaluationReport;
   }
   export interface ProvidedContext {
-  baseline?: string;
-  debug?: boolean;
+    baseline?: string;
+    debug?: boolean;
     overrides?: Record<string, any>;
-   }
- }
+  }
+}
 
 const nanoid = customAlphabet('1234567890abcdefghijklmnopqrstuvwxyz', 10);
 

--- a/packages/ai/src/evals/eval.ts
+++ b/packages/ai/src/evals/eval.ts
@@ -21,47 +21,6 @@ import { findBaseline, findEvaluationCases } from './eval.service';
 import { DEFAULT_TIMEOUT } from './run-vitest';
 import { getGlobalFlagOverrides } from './context/global-flags';
 
-// Helper to prune/truncate flags for span attributes/console safety
-function pruneFlags(
-  obj: any,
-  options: { maxEntries?: number; maxStringLen?: number; maxDepth?: number } = {},
-): any {
-  const { maxEntries = 50, maxStringLen = 200, maxDepth = 2 } = options;
-  const seen = new WeakSet();
-
-  function helper(value: any, depth: number): any {
-    if (value == null) return value;
-    if (typeof value === 'string') {
-      return value.length > maxStringLen ? value.slice(0, maxStringLen) + '…' : value;
-    }
-    if (typeof value !== 'object') return value;
-    if (seen.has(value)) return '[Circular]';
-    seen.add(value);
-
-    if (Array.isArray(value)) {
-      return depth >= maxDepth
-        ? `[Array(${value.length})]`
-        : value.slice(0, maxEntries).map((v) => helper(v, depth + 1));
-    }
-
-    if (depth >= maxDepth) return '[Object]';
-
-    const out: Record<string, any> = {};
-    let count = 0;
-    for (const [k, v] of Object.entries(value)) {
-      out[k] = helper(v, depth + 1);
-      if (++count >= maxEntries) break;
-    }
-    return out;
-  }
-
-  try {
-    return helper(obj, 0);
-  } catch {
-    return '[Unserializable]';
-  }
-}
-
 declare module 'vitest' {
   interface TestSuiteMeta {
     evaluation: EvaluationReport;

--- a/packages/ai/src/evals/eval.types.ts
+++ b/packages/ai/src/evals/eval.types.ts
@@ -236,4 +236,6 @@ export type EvaluationReport = {
   };
 };
 
+// TODO: BEFORE MERGE - why are these two separate things? Very confusing....
 export type MetaWithEval = TaskMeta & { evaluation: EvaluationReport };
+export type MetaWithCase = TaskMeta & { case: EvalCaseReport };

--- a/packages/ai/src/evals/reporter.console-utils.ts
+++ b/packages/ai/src/evals/reporter.console-utils.ts
@@ -155,20 +155,6 @@ export function printConfigHeader() {
   console.log(' ', c.bgWhite(c.blackBright(' Config ')));
 }
 
-// export function maybePrintFlagOverrides(configEnd: EvaluationReport['configEnd']) {
-//   const overrides = configEnd?.overrides;
-
-//   if (overrides && Object.keys(overrides).length) {
-//     const entries = Object.entries(overrides).slice(0, 20);
-//     const formatted = entries.map(([k, v]) => `${k}=${truncate(stringify(v), 80)}`).join(', ');
-//     console.log('   ', c.dim('overrides'), formatted);
-//     if (Object.keys(overrides).length > entries.length) {
-//       console.log('   ', c.dim(`… +${Object.keys(overrides).length - entries.length} more`));
-//     }
-//     console.log('');
-//   }
-// }
-
 export function maybePrintFlags(configEnd: EvaluationReport['configEnd']) {
   const defaults = configEnd?.flags ?? {};
   const overrides = configEnd?.overrides ?? {};
@@ -211,8 +197,8 @@ export function maybePrintFlags(configEnd: EvaluationReport['configEnd']) {
   console.log('');
 }
 
-export function printResultLink(testMeta: MetaWithCase) {
-  const url = `https://app.axiom.co/evaluations/${testMeta.evaluation.name}/${testMeta.evaluation.id}`;
+export function printResultLink(testMeta: MetaWithCase, axiomUrl: string) {
+  const url = `${axiomUrl}/evaluations/${testMeta.evaluation.name}/${testMeta.evaluation.id}`;
   console.log(
     ' ',
     `see results for ${testMeta.evaluation.name}-${testMeta.evaluation.version} at ${url}`,

--- a/packages/ai/src/evals/reporter.console-utils.ts
+++ b/packages/ai/src/evals/reporter.console-utils.ts
@@ -118,7 +118,7 @@ export function printTestCaseScores(
         c.magentaBright(blScoreText),
         '->',
         c.blueBright(scoreValue),
-        diff > 0 ? c.green('+' + diffText) : c.red(diffText),
+        diff > 0 ? c.green('+' + diffText) : diff < 0 ? c.red(diffText) : diffText,
       );
     } else {
       console.log('   ', k, c.blueBright(scoreValue));

--- a/packages/ai/src/evals/reporter.console-utils.ts
+++ b/packages/ai/src/evals/reporter.console-utils.ts
@@ -149,12 +149,14 @@ export function printOutOfScopeFlags(testMeta: MetaWithCase) {
   }
 }
 
+export function printConfigHeader() {
+  console.log('');
+  console.log(' ', c.bgWhite(c.blackBright(' Config ')));
+}
+
 export function maybePrintFlagOverrides(configEnd: EvaluationReport['configEnd']) {
   const overrides = configEnd?.overrides;
 
-  if (!overrides) return;
-
-  console.log(' ', c.bgWhite(c.blackBright(' Config ')));
   if (overrides && Object.keys(overrides).length) {
     const entries = Object.entries(overrides).slice(0, 20);
     const formatted = entries.map(([k, v]) => `${k}=${truncate(stringify(v), 80)}`).join(', ');
@@ -162,6 +164,7 @@ export function maybePrintFlagOverrides(configEnd: EvaluationReport['configEnd']
     if (Object.keys(overrides).length > entries.length) {
       console.log('   ', c.dim(`… +${Object.keys(overrides).length - entries.length} more`));
     }
+    console.log('');
   }
 }
 
@@ -177,6 +180,7 @@ export function maybePrintFlagDefaults(configEnd: EvaluationReport['configEnd'])
       '{',
       indented.slice(1), // remove first `{`
     );
+    console.log('');
   }
 }
 

--- a/packages/ai/src/evals/reporter.console-utils.ts
+++ b/packages/ai/src/evals/reporter.console-utils.ts
@@ -1,0 +1,194 @@
+import c from 'tinyrainbow';
+
+import type { Evaluation, EvaluationReport, MetaWithCase, MetaWithEval } from './eval.types';
+import type { TestSuite } from 'vitest/node.js';
+
+export function truncate(str: string, max: number): string {
+  return str.length > max ? str.slice(0, max) + '…' : str;
+}
+
+export function stringify(value: any): string {
+  try {
+    if (typeof value === 'string') return value;
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+export function printEvalNameAndFileName(testSuite: TestSuite, meta: MetaWithEval) {
+  const cwd = process.cwd();
+
+  console.log(
+    ' ',
+    c.bgCyan(c.black(` ${testSuite.project.name} `)),
+    c.bgBlue(c.black(` ${meta.evaluation.name}-${meta.evaluation.version} `)),
+    c.dim(`(${testSuite.children.size} cases)`),
+  );
+
+  console.log(' ', c.dim(testSuite.module.moduleId.replace(cwd, '')));
+}
+
+export function printBaselineNameAndVersion(testMeta: MetaWithEval) {
+  // print baseline name and version if found
+  if (testMeta.evaluation.baseline) {
+    console.log(
+      ' ',
+      ' baseline ',
+      c.bgMagenta(
+        c.black(` ${testMeta.evaluation.baseline.name}-${testMeta.evaluation.baseline.version} `),
+      ),
+    );
+  } else {
+    console.log(' ', c.bgWhite(c.blackBright(' baseline: ')), 'none');
+  }
+
+  console.log('');
+}
+
+// Print runtime flags actually used for this case (up to 20 entries)
+export function printRuntimeFlags(testMeta: MetaWithCase) {
+  if (testMeta.case.runtimeFlags && Object.keys(testMeta.case.runtimeFlags).length > 0) {
+    const entries = Object.entries(testMeta.case.runtimeFlags);
+    const shown = entries.slice(0, 20);
+    console.log('   ', c.dim('runtime flags'));
+    for (const [k, v] of shown) {
+      switch (v.kind) {
+        case 'replaced': {
+          const valText = truncate(stringify(v.value), 80);
+          const defText = truncate(stringify(v.default), 80);
+          console.log('     ', `${k}: ${valText} (default: ${defText})`);
+          break;
+        }
+        case 'introduced': {
+          const valText = truncate(stringify(v.value), 80);
+          console.log('     ', `${k}: ${valText} (no default)`);
+          break;
+        }
+      }
+    }
+    if (entries.length > shown.length) {
+      console.log('     ', c.dim(`… +${entries.length - shown.length} more`));
+    }
+  }
+}
+
+export function printTestCaseCountStartDuration(
+  testSuite: TestSuite,
+  startTime: number,
+  duration: string,
+) {
+  console.log(' ');
+  console.log(' ', c.dim('Cases'), testSuite.children.size);
+  console.log(' ', c.dim('Start at'), new Date(startTime).toTimeString());
+  console.log(' ', c.dim('Duration'), `${duration}s`);
+}
+
+export function printTestCaseSuccessOrFailed(testMeta: MetaWithCase, ok: boolean) {
+  const index = testMeta.case.index;
+
+  if (ok) {
+    console.log(' ', c.yellow(` \u2714 case ${index}:`));
+  } else {
+    console.log(' ', c.red(` \u2716 case ${index}: failed`));
+    for (const e of testMeta.case.errors ?? []) {
+      console.log('', e.message);
+    }
+  }
+}
+
+export function printTestCaseScores(
+  testMeta: MetaWithCase,
+  baseline: Evaluation | null | undefined,
+) {
+  const index = testMeta.case.index;
+
+  Object.keys(testMeta.case.scores).forEach((k) => {
+    const v = testMeta.case.scores[k].score ? testMeta.case.scores[k].score : 0;
+    const scoreValue = Number(v * 100).toFixed(2) + '%';
+
+    if (baseline?.cases[index]?.scores[k]) {
+      const baselineScoreValue = baseline.cases[index].scores[k].value;
+      const diff = v - baselineScoreValue;
+      const diffText = Number(diff * 100).toFixed(2) + '%';
+      const blScoreText = Number(baselineScoreValue * 100).toFixed(2) + '%';
+      console.log(
+        '   ',
+        k,
+        c.magentaBright(blScoreText),
+        '->',
+        c.blueBright(scoreValue),
+        diff > 0 ? c.green('+' + diffText) : c.red(diffText),
+      );
+    } else {
+      console.log('   ', k, c.blueBright(scoreValue));
+    }
+
+    return [k, scoreValue];
+  });
+}
+
+export function printOutOfScopeFlags(testMeta: MetaWithCase) {
+  if (testMeta.case.outOfScopeFlags && testMeta.case.outOfScopeFlags.length > 0) {
+    const pickedFlagsText = testMeta.case.pickedFlags
+      ? `(picked: ${testMeta.case.pickedFlags.map((f) => `'${f}'`).join(', ')})`
+      : '(none)';
+    console.log('   ', c.yellow(`⚠ Out-of-scope flags: ${pickedFlagsText}`));
+    testMeta.case.outOfScopeFlags.forEach((flag) => {
+      const timeStr = new Date(flag.accessedAt).toLocaleTimeString();
+      console.log('     ', `${flag.flagPath} (at ${timeStr})`);
+
+      // Show top stack trace frames
+      if (flag.stackTrace && flag.stackTrace.length > 0) {
+        flag.stackTrace.forEach((frame, i) => {
+          const prefix = i === flag.stackTrace.length - 1 ? ' └─' : ' ├─';
+          console.log('     ', c.dim(`${prefix} ${frame}`));
+        });
+      }
+    });
+  }
+}
+
+export function maybePrintFlagOverrides(configEnd: EvaluationReport['configEnd']) {
+  const overrides = configEnd?.overrides;
+
+  if (!overrides) return;
+
+  console.log(' ', c.bgWhite(c.blackBright(' Config ')));
+  if (overrides && Object.keys(overrides).length) {
+    const entries = Object.entries(overrides).slice(0, 20);
+    const formatted = entries.map(([k, v]) => `${k}=${truncate(stringify(v), 80)}`).join(', ');
+    console.log('   ', c.dim('overrides'), formatted);
+    if (Object.keys(overrides).length > entries.length) {
+      console.log('   ', c.dim(`… +${Object.keys(overrides).length - entries.length} more`));
+    }
+  }
+}
+
+export function maybePrintFlagDefaults(configEnd: EvaluationReport['configEnd']) {
+  const flags = configEnd?.flags;
+
+  if (flags && Object.keys(flags).length) {
+    const formatted = JSON.stringify(flags, null, 2);
+    const indented = formatted.replace(/\n/g, '\n    ');
+    console.log(
+      '   ',
+      c.dim('flag defaults:'),
+      '{',
+      indented.slice(1), // remove first `{`
+    );
+  }
+}
+
+export function printResultLink(testMeta: MetaWithCase) {
+  const url = `https://app.axiom.co/evaluations/${testMeta.evaluation.name}/${testMeta.evaluation.id}`;
+  console.log(
+    ' ',
+    `see results for ${testMeta.evaluation.name}-${testMeta.evaluation.version} at ${url}`,
+  );
+}
+
+export function printDivider() {
+  console.log(' ', c.cyanBright('=== === === === === === === === === === === === === === === ==='));
+  console.log('');
+}

--- a/packages/ai/src/evals/reporter.ts
+++ b/packages/ai/src/evals/reporter.ts
@@ -1,16 +1,9 @@
 import type { SerializedError } from 'vitest';
 import type { Reporter, TestCase, TestModule, TestRunEndReason, TestSuite } from 'vitest/node.js';
-import type { TaskMeta } from 'vitest/index.cjs';
 import c from 'tinyrainbow';
 
 import { findEvaluationCases } from './eval.service';
-import type {
-  EvalCaseReport,
-  Evaluation,
-  EvaluationReport,
-  MetaWithCase,
-  MetaWithEval,
-} from './eval.types';
+import type { Evaluation, EvaluationReport, MetaWithCase, MetaWithEval } from './eval.types';
 import {
   maybePrintFlags,
   printBaselineNameAndVersion,
@@ -18,6 +11,7 @@ import {
   printDivider,
   printEvalNameAndFileName,
   printOutOfScopeFlags,
+  printResultLink,
   printRuntimeFlags,
   printTestCaseCountStartDuration,
   printTestCaseScores,
@@ -64,7 +58,7 @@ export class AxiomReporter implements Reporter {
   }
 
   onTestCaseReady(test: TestCase) {
-    const meta = test.meta() as TaskMeta & { case: EvalCaseReport };
+    const meta = test.meta() as MetaWithCase;
 
     // TODO: there seem to be some cases where `meta` is undefined
     // maybe we get here to early?
@@ -74,6 +68,7 @@ export class AxiomReporter implements Reporter {
   }
 
   onTestSuiteResult(testSuite: TestSuite) {
+    const meta = testSuite.meta() as MetaWithCase;
     // test suite won't have any meta because its skipped
     if (testSuite.state() === 'skipped') {
       return;
@@ -92,8 +87,11 @@ export class AxiomReporter implements Reporter {
     console.log('');
 
     const DEBUG = process.env.AXIOM_DEBUG === 'true';
+    const AXIOM_URL = (process.env.AXIOM_URL ?? 'https://api.axiom.co').replace('api', 'app');
     if (!DEBUG) {
+      printResultLink(meta, AXIOM_URL);
     }
+
     printDivider();
   }
 

--- a/packages/ai/src/evals/reporter.ts
+++ b/packages/ai/src/evals/reporter.ts
@@ -12,8 +12,7 @@ import type {
   MetaWithEval,
 } from './eval.types';
 import {
-  maybePrintFlagDefaults,
-  maybePrintFlagOverrides,
+  maybePrintFlags,
   printBaselineNameAndVersion,
   printConfigHeader,
   printDivider,
@@ -132,7 +131,6 @@ export class AxiomReporter implements Reporter {
    */
   private printConfigEnd(configEnd: EvaluationReport['configEnd']) {
     printConfigHeader();
-    maybePrintFlagOverrides(configEnd);
-    maybePrintFlagDefaults(configEnd);
+    maybePrintFlags(configEnd);
   }
 }

--- a/packages/ai/src/evals/reporter.ts
+++ b/packages/ai/src/evals/reporter.ts
@@ -142,10 +142,14 @@ export class AxiomReporter implements Reporter {
     }
 
     console.log('');
-    console.log(
-      ' ',
-      `see results for ${meta.evaluation.name}-${meta.evaluation.version} at ${url}`,
-    );
+
+    const DEBUG = process.env.AXIOM_DEBUG === 'true';
+    if (!DEBUG) {
+      console.log(
+        ' ',
+        `see results for ${meta.evaluation.name}-${meta.evaluation.version} at ${url}`,
+      );
+    }
     console.log(
       ' ',
       c.cyanBright('=== === === === === === === === === === === === === === === ==='),

--- a/packages/ai/src/evals/reporter.ts
+++ b/packages/ai/src/evals/reporter.ts
@@ -4,20 +4,25 @@ import type { TaskMeta } from 'vitest/index.cjs';
 import c from 'tinyrainbow';
 
 import { findEvaluationCases } from './eval.service';
-import type { EvalCaseReport, Evaluation, EvaluationReport, MetaWithEval } from './eval.types';
-
-function truncate(str: string, max: number): string {
-  return str.length > max ? str.slice(0, max) + '…' : str;
-}
-
-function stringify(value: any): string {
-  try {
-    if (typeof value === 'string') return value;
-    return JSON.stringify(value);
-  } catch {
-    return String(value);
-  }
-}
+import type {
+  EvalCaseReport,
+  Evaluation,
+  EvaluationReport,
+  MetaWithCase,
+  MetaWithEval,
+} from './eval.types';
+import {
+  maybePrintFlagDefaults,
+  maybePrintFlagOverrides,
+  printBaselineNameAndVersion,
+  printDivider,
+  printEvalNameAndFileName,
+  printOutOfScopeFlags,
+  printRuntimeFlags,
+  printTestCaseCountStartDuration,
+  printTestCaseScores,
+  printTestCaseSuccessOrFailed,
+} from './reporter.console-utils';
 
 /**
  * Custom Vitest reporter for Axiom AI evaluations.
@@ -38,7 +43,7 @@ export class AxiomReporter implements Reporter {
   }
 
   async onTestSuiteReady(_testSuite: TestSuite) {
-    const meta = _testSuite.meta() as TaskMeta & { evaluation: EvaluationReport };
+    const meta = _testSuite.meta() as MetaWithEval;
     if (_testSuite.state() === 'skipped') {
       return;
     }
@@ -47,36 +52,15 @@ export class AxiomReporter implements Reporter {
       // load baseline data
       this.baseline = await findEvaluationCases(baseline.id);
     }
-    const cwd = process.cwd();
 
-    console.log(
-      ' ',
-      c.bgCyan(c.black(` ${_testSuite.project.name} `)),
-      c.bgBlue(c.black(` ${meta.evaluation.name}-${meta.evaluation.version} `)),
-      c.dim(`(${_testSuite.children.size} cases)`),
-    );
+    printEvalNameAndFileName(_testSuite, meta);
 
-    console.log(' ', c.dim(_testSuite.module.moduleId.replace(cwd, '')));
-
-    // print baseline name and version if found
-    if (meta.evaluation.baseline) {
-      console.log(
-        ' ',
-        ' baseline ',
-        c.bgMagenta(
-          c.black(` ${meta.evaluation.baseline.name}-${meta.evaluation.baseline.version} `),
-        ),
-      );
-    } else {
-      console.log(' ', c.bgWhite(c.blackBright(' baseline: ')), 'none');
-    }
+    printBaselineNameAndVersion(meta);
 
     // capture end-of-run config snapshot (first non-empty wins)
     if (meta.evaluation.configEnd && !this._endOfRunConfigEnd) {
       this._endOfRunConfigEnd = meta.evaluation.configEnd;
     }
-
-    console.log('');
   }
 
   onTestCaseReady(test: TestCase) {
@@ -98,13 +82,7 @@ export class AxiomReporter implements Reporter {
     // calculate test duration in seconds
     const duration = Number((performance.now() - this.start) / 1000).toFixed(2);
 
-    console.log(' ');
-    console.log(' ', c.dim('Cases'), testSuite.children.size);
-    console.log(' ', c.dim('Start at'), new Date(this.startTime).toTimeString());
-    console.log(' ', c.dim('Duration'), `${duration}s`);
-
-    const meta = testSuite.meta() as TaskMeta & { evaluation: EvaluationReport };
-    const url = `https://app.axiom.co/evaluations/${meta.evaluation.name}/${meta.evaluation.id}`;
+    printTestCaseCountStartDuration(testSuite, this.startTime, duration);
 
     for (const test of testSuite.children) {
       if (test.type !== 'test') return;
@@ -115,16 +93,8 @@ export class AxiomReporter implements Reporter {
 
     const DEBUG = process.env.AXIOM_DEBUG === 'true';
     if (!DEBUG) {
-      console.log(
-        ' ',
-        `see results for ${meta.evaluation.name}-${meta.evaluation.version} at ${url}`,
-      );
     }
-    console.log(
-      ' ',
-      c.cyanBright('=== === === === === === === === === === === === === === === ==='),
-    );
-    console.log('');
+    printDivider();
   }
 
   async onTestRunEnd(
@@ -141,120 +111,27 @@ export class AxiomReporter implements Reporter {
 
   private printCaseResult(test: TestCase) {
     const ok = test.ok();
-    const testMeta = test.meta() as MetaWithEval;
+    const testMeta = test.meta() as MetaWithCase;
 
-    if (!testMeta || !testMeta.case) {
+    if (!testMeta?.case) {
       return;
     }
-    const index = testMeta.case.index;
 
-    if (ok) {
-      console.log(' ', c.yellow(` \u2714 case ${index}:`));
-    } else {
-      console.log(' ', c.red(` \u2716 case ${index}: failed`));
-      for (const e of testMeta.case.errors ?? []) {
-        console.log('', e.message);
-      }
-    }
+    printTestCaseSuccessOrFailed(testMeta, ok);
 
-    // print scores
-    Object.keys(testMeta.case.scores).forEach((k) => {
-      const v = testMeta.case.scores[k].score ? testMeta.case.scores[k].score : 0;
-      const scoreValue = Number(v * 100).toFixed(2) + '%';
+    printTestCaseScores(testMeta, this.baseline);
 
-      if (this.baseline && this.baseline.cases[index] && this.baseline.cases[index].scores[k]) {
-        const baselineScoreValue = this.baseline.cases[index].scores[k].value;
-        const diff = v - baselineScoreValue;
-        const diffText = Number(diff * 100).toFixed(2) + '%';
-        const blScoreText = Number(baselineScoreValue * 100).toFixed(2) + '%';
-        console.log(
-          '   ',
-          k,
-          c.magentaBright(blScoreText),
-          '->',
-          c.blueBright(scoreValue),
-          diff > 0 ? c.green('+' + diffText) : c.red(diffText),
-        );
-      } else {
-        console.log('   ', k, c.blueBright(scoreValue));
-      }
+    printRuntimeFlags(testMeta);
 
-      return [k, scoreValue];
-    });
-
-    // Print runtime flags actually used for this case (up to 20 entries)
-    if (testMeta.case.runtimeFlags && Object.keys(testMeta.case.runtimeFlags).length > 0) {
-      const entries = Object.entries(testMeta.case.runtimeFlags);
-      const shown = entries.slice(0, 20);
-      console.log('   ', c.dim('runtime flags'));
-      for (const [k, v] of shown) {
-        switch (v.kind) {
-          case 'replaced': {
-            const valText = truncate(stringify(v.value), 80);
-            const defText = truncate(stringify(v.default), 80);
-            console.log('     ', `${k}: ${valText} (default: ${defText})`);
-            break;
-          }
-          case 'introduced': {
-            const valText = truncate(stringify(v.value), 80);
-            console.log('     ', `${k}: ${valText} (no default)`);
-            break;
-          }
-        }
-      }
-      if (entries.length > shown.length) {
-        console.log('     ', c.dim(`… +${entries.length - shown.length} more`));
-      }
-    }
-
-    // Print out-of-scope flags for this case
-    if (testMeta.case.outOfScopeFlags && testMeta.case.outOfScopeFlags.length > 0) {
-      const pickedFlagsText = testMeta.case.pickedFlags
-        ? `(picked: ${testMeta.case.pickedFlags.map((f) => `'${f}'`).join(', ')})`
-        : '(none)';
-      console.log('   ', c.yellow(`⚠ Out-of-scope flags: ${pickedFlagsText}`));
-      testMeta.case.outOfScopeFlags.forEach((flag) => {
-        const timeStr = new Date(flag.accessedAt).toLocaleTimeString();
-        console.log('     ', `${flag.flagPath} (at ${timeStr})`);
-
-        // Show top stack trace frames
-        if (flag.stackTrace && flag.stackTrace.length > 0) {
-          flag.stackTrace.forEach((frame, i) => {
-            const prefix = i === flag.stackTrace.length - 1 ? ' └─' : ' ├─';
-            console.log('     ', c.dim(`${prefix} ${frame}`));
-          });
-        }
-      });
-    }
+    printOutOfScopeFlags(testMeta);
   }
 
   /**
    * End-of-suite config summary (console only)
    */
   private printConfigEnd(configEnd: EvaluationReport['configEnd']) {
-    if (configEnd) {
-      const { overrides, flags } = configEnd;
-      console.log('');
-      console.log(' ', c.bgWhite(c.blackBright(' Config ')));
-      if (overrides && Object.keys(overrides).length) {
-        const entries = Object.entries(overrides).slice(0, 20);
-        const formatted = entries.map(([k, v]) => `${k}=${truncate(stringify(v), 80)}`).join(', ');
-        console.log('   ', c.dim('overrides'), formatted);
-        if (Object.keys(overrides).length > entries.length) {
-          console.log('   ', c.dim(`… +${Object.keys(overrides).length - entries.length} more`));
-        }
-      }
-      if (flags && Object.keys(flags).length) {
-        const formatted = JSON.stringify(flags, null, 2);
-        const indented = formatted.replace(/\n/g, '\n    ');
-        console.log(
-          '   ',
-          c.dim('flag defaults:'),
-          '{',
-          indented.slice(1), // remove first `{`
-        );
-      }
-      console.log('');
-    }
+    maybePrintFlagOverrides(configEnd);
+
+    maybePrintFlagDefaults(configEnd);
   }
 }

--- a/packages/ai/src/evals/reporter.ts
+++ b/packages/ai/src/evals/reporter.ts
@@ -15,6 +15,7 @@ import {
   maybePrintFlagDefaults,
   maybePrintFlagOverrides,
   printBaselineNameAndVersion,
+  printConfigHeader,
   printDivider,
   printEvalNameAndFileName,
   printOutOfScopeFlags,
@@ -130,8 +131,8 @@ export class AxiomReporter implements Reporter {
    * End-of-suite config summary (console only)
    */
   private printConfigEnd(configEnd: EvaluationReport['configEnd']) {
+    printConfigHeader();
     maybePrintFlagOverrides(configEnd);
-
     maybePrintFlagDefaults(configEnd);
   }
 }

--- a/packages/ai/src/evals/run-vitest.ts
+++ b/packages/ai/src/evals/run-vitest.ts
@@ -14,6 +14,7 @@ export const runVitest = async (
     include: string[];
     testNamePattern?: RegExp;
     debug?: boolean;
+    overrides?: Record<string, any>;
   },
 ) => {
   // Initialize instrumentation explicitly based on debug flag
@@ -41,6 +42,7 @@ export const runVitest = async (
     provide: {
       baseline: opts.baseline,
       debug: opts.debug,
+      overrides: opts.overrides,
     },
   });
 

--- a/packages/ai/src/evals/run-vitest.ts
+++ b/packages/ai/src/evals/run-vitest.ts
@@ -1,6 +1,6 @@
 import { createVitest, registerConsoleShortcuts } from 'vitest/node';
 import { AxiomReporter } from './reporter';
-import { flush } from './instrument';
+import { flush, initInstrumentation } from './instrument';
 
 export const DEFAULT_TIMEOUT = 10000;
 
@@ -11,8 +11,16 @@ export const runVitest = async (
     baseline?: string;
     include: string[];
     testNamePattern?: RegExp;
+    debug?: boolean;
   },
 ) => {
+  // Initialize instrumentation explicitly based on debug flag
+  initInstrumentation({ enabled: !opts.debug });
+
+  if (opts.debug) {
+    console.log('Debug mode enabled');
+  }
+
   const vi = await createVitest('test', {
     root: dir ? dir : process.cwd(),
     mode: 'test',
@@ -30,6 +38,7 @@ export const runVitest = async (
     globals: true,
     provide: {
       baseline: opts.baseline,
+      debug: opts.debug,
     },
   });
 

--- a/packages/ai/src/evals/run-vitest.ts
+++ b/packages/ai/src/evals/run-vitest.ts
@@ -1,3 +1,5 @@
+import c from 'tinyrainbow';
+
 import { createVitest, registerConsoleShortcuts } from 'vitest/node';
 import { AxiomReporter } from './reporter';
 import { flush, initInstrumentation } from './instrument';
@@ -18,7 +20,7 @@ export const runVitest = async (
   initInstrumentation({ enabled: !opts.debug });
 
   if (opts.debug) {
-    console.log('Debug mode enabled');
+    console.log(c.bgWhite(c.blackBright(' Debug mode enabled ')));
   }
 
   const vi = await createVitest('test', {

--- a/packages/ai/src/otel/initAxiomAI.ts
+++ b/packages/ai/src/otel/initAxiomAI.ts
@@ -85,11 +85,14 @@ export function getGlobalTracer(): Tracer {
 
   // Warn if initAxiomAI was never called
   if (!scope) {
-    console.warn(
-      '[AxiomAI] AXIOM_AI_SCOPE_KEY is undefined. This probably means that ' +
-        'initAxiomAI() was never called. ' +
-        'Make sure to call initAxiomAI({ tracer }) in your instrumentation setup.',
-    );
+    const DEBUG = process.env.AXIOM_DEBUG === 'true';
+    if (!DEBUG) {
+      console.warn(
+        '[AxiomAI] AXIOM_AI_SCOPE_KEY is undefined. This probably means that ' +
+          'initAxiomAI() was never called. ' +
+          'Make sure to call initAxiomAI({ tracer }) in your instrumentation setup.',
+      );
+    }
   }
 
   let { name, version } = scope || { name: packageJson.name, version: packageJson.version };

--- a/packages/ai/src/otel/utils/wrapperUtils.ts
+++ b/packages/ai/src/otel/utils/wrapperUtils.ts
@@ -171,10 +171,13 @@ export function getTracer(): Tracer {
   const tracer = getGlobalTracer();
 
   if (isNoOpTracerProvider()) {
-    console.warn(
-      '[AxiomAI] No TracerProvider registered - spans will be no-op. ' +
-        'Make sure to call initAxiomAI() after your OpenTelemetry SDK has started (sdk.start()).',
-    );
+    const DEBUG = process.env.AXIOM_DEBUG === 'true';
+    if (!DEBUG) {
+      console.warn(
+        '[AxiomAI] No TracerProvider registered - spans will be no-op. ' +
+          'Make sure to call initAxiomAI() after your OpenTelemetry SDK has started (sdk.start()).',
+      );
+    }
   }
 
   return tracer;

--- a/packages/ai/src/otel/withSpan.ts
+++ b/packages/ai/src/otel/withSpan.ts
@@ -111,9 +111,12 @@ export function withSpan<Return>(
 
       // We don't warn for other non-recording cases (sampling=DROP, etc.) as those may be intentional
       if (providerIsNoOp) {
-        console.warn(
-          '[AxiomAI] No TracerProvider registered - spans are no-op. Make sure to call initAxiomAI() after your OpenTelemetry SDK has started.',
-        );
+        const DEBUG = process.env.AXIOM_DEBUG === 'true';
+        if (!DEBUG) {
+          console.warn(
+            '[AxiomAI] No TracerProvider registered - spans are no-op. Make sure to call initAxiomAI() after your OpenTelemetry SDK has started.',
+          );
+        }
       }
     }
 

--- a/packages/ai/src/util/deep-equal.ts
+++ b/packages/ai/src/util/deep-equal.ts
@@ -1,0 +1,147 @@
+/**
+ * Copied from Remeda - https://github.com/remeda/remeda/blob/v2.32.0/packages/remeda/src/isDeepEqual.ts
+ */
+
+export function deepEqual<T>(data: unknown, other: T): data is T {
+  if (data === other) {
+    return true;
+  }
+
+  if (Object.is(data, other)) {
+    // We want to ignore the slight differences between `===` and `Object.is` as
+    // both of them largely define equality from a semantic point-of-view.
+    return true;
+  }
+
+  if (typeof data !== 'object' || typeof other !== 'object') {
+    return false;
+  }
+
+  if (data === null || other === null) {
+    return false;
+  }
+
+  if (Object.getPrototypeOf(data) !== Object.getPrototypeOf(other)) {
+    // If the objects don't share a prototype it's unlikely that they are
+    // semantically equal. It is technically possible to build 2 prototypes that
+    // act the same but are not equal (at the reference level, checked via
+    // `===`) and then create 2 objects that are equal although we would fail on
+    // them. Because this is so unlikely, the optimization we gain here for the
+    // rest of the function by assuming that `other` is of the same type as
+    // `data` is more than worth it.
+    return false;
+  }
+
+  if (Array.isArray(data)) {
+    return isDeepEqualArrays(data, other as unknown as ReadonlyArray<unknown>);
+  }
+
+  if (data instanceof Map) {
+    return isDeepEqualMaps(data, other as unknown as Map<unknown, unknown>);
+  }
+
+  if (data instanceof Set) {
+    return isDeepEqualSets(data, other as unknown as Set<unknown>);
+  }
+
+  if (data instanceof Date) {
+    return data.getTime() === (other as unknown as Date).getTime();
+  }
+
+  if (data instanceof RegExp) {
+    return data.toString() === (other as unknown as RegExp).toString();
+  }
+
+  // At this point we only know that the 2 objects share a prototype and are not
+  // any of the previous types. They could be plain objects (Object.prototype),
+  // they could be classes, they could be other built-ins, or they could be
+  // something weird. We assume that comparing values by keys is enough to judge
+  // their equality.
+
+  if (Object.keys(data).length !== Object.keys(other).length) {
+    return false;
+  }
+
+  for (const [key, value] of Object.entries(data)) {
+    if (!(key in other)) {
+      return false;
+    }
+
+    if (
+      !deepEqual(
+        value,
+        // @ts-expect-error [ts7053] - We already checked that `other` has `key`
+        other[key],
+      )
+    ) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function isDeepEqualArrays(data: ReadonlyArray<unknown>, other: ReadonlyArray<unknown>): boolean {
+  if (data.length !== other.length) {
+    return false;
+  }
+
+  for (const [index, item] of data.entries()) {
+    if (!deepEqual(item, other[index])) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function isDeepEqualMaps(
+  data: ReadonlyMap<unknown, unknown>,
+  other: ReadonlyMap<unknown, unknown>,
+): boolean {
+  if (data.size !== other.size) {
+    return false;
+  }
+
+  for (const [key, value] of data.entries()) {
+    if (!other.has(key)) {
+      return false;
+    }
+
+    if (!deepEqual(value, other.get(key))) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function isDeepEqualSets(data: ReadonlySet<unknown>, other: ReadonlySet<unknown>): boolean {
+  if (data.size !== other.size) {
+    return false;
+  }
+
+  // To ensure we only count each item once we need to "remember" which items of
+  // the other set we've already matched against. We do this by creating a copy
+  // of the other set and removing items from it as we find them in the data
+  // set.
+  const otherCopy = [...other];
+
+  for (const dataItem of data) {
+    let isFound = false;
+
+    for (const [index, otherItem] of otherCopy.entries()) {
+      if (deepEqual(dataItem, otherItem)) {
+        isFound = true;
+        otherCopy.splice(index, 1);
+        break;
+      }
+    }
+
+    if (!isFound) {
+      return false;
+    }
+  }
+
+  return true;
+}


### PR DESCRIPTION
adds `axiom eval --debug`

- does not contact axiom for baselines
- does not send traces to axiom
- prints some additional things
  - "Debug mode enabled" at the start
  - An overview of flags at the end

<img width="1254" height="232" alt="CleanShot 2025-09-26 at 18 53 25@2x" src="https://github.com/user-attachments/assets/4c8bb39d-1dce-403a-b615-50f4ba78f65e" />

<img width="1000" height="174" alt="CleanShot 2025-09-26 at 18 52 16@2x" src="https://github.com/user-attachments/assets/5800bdd6-f6bb-4fb1-a899-3beffa56a148" />

