### PR TITLE
fix(prompt): disable HTML entity escaping for AI prompts

### DIFF
--- a/packages/ai/src/prompt/parsers/handlebars.ts
+++ b/packages/ai/src/prompt/parsers/handlebars.ts
@@ -1,7 +1,19 @@
 import Handlebars from 'handlebars';
 
 /**
+ * Create a custom Handlebars environment that doesn't escape HTML entities.
+ * Since prompt templates are intended for AI models (plain text) rather than HTML,
+ * we disable HTML escaping to prevent characters like quotes and brackets
+ * from being converted to HTML entities (e.g., ' -> &#x27;).
+ */
+const handlebarsNoEscape = Handlebars.create();
+handlebarsNoEscape.Utils.escapeExpression = (str: any) => String(str);
+
+/**
  * Parses a Handlebars template with the provided context.
+ *
+ * Uses a custom Handlebars instance that disables HTML escaping, since the
+ * output is intended for AI models (plain text) rather than HTML.
  *
  * @param prompt The Handlebars template string.
  * @param options An object containing the context.
@@ -21,7 +33,7 @@ export const handlebarsParse = async (
   prompt: string,
   { context }: { context: Record<string, any> },
 ) => {
-  const template = Handlebars.compile(prompt);
+  const template = handlebarsNoEscape.compile(prompt);
   const result = template(context);
   return result ?? '';
 };

--- a/packages/ai/test/prompt/html-escaping.test.ts
+++ b/packages/ai/test/prompt/html-escaping.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import { handlebarsParse } from '../../src/prompt/parsers/handlebars';
+
+describe('Handlebars HTML escaping', () => {
+  it('should not HTML-escape special characters in APL queries', async () => {
+    const template = 'Explain this APL query:\n{{query}}';
+    const context = {
+      query: "['logs'] | where ['severity'] == \"error\"",
+    };
+
+    const result = await handlebarsParse(template, { context });
+
+    // Should NOT contain HTML entities
+    expect(result).not.toContain('&#x27;');
+    expect(result).not.toContain('&#x3D;');
+    expect(result).not.toContain('&quot;');
+
+    // Should contain the original characters
+    expect(result).toContain("['logs']");
+    expect(result).toContain("['severity']");
+    expect(result).toContain('==');
+    expect(result).toContain('"error"');
+
+    // Exact match
+    expect(result).toBe("Explain this APL query:\n['logs'] | where ['severity'] == \"error\"");
+  });
+
+  it('should preserve special characters in user content', async () => {
+    const template = '{{#if subject}}Subject: {{subject}}\n{{/if}}Content: {{content}}';
+    const context = {
+      subject: 'Query Help',
+      content: 'How do I use [\'field\'] == "value" in APL?',
+    };
+
+    const result = await handlebarsParse(template, { context });
+
+    // Should not escape quotes or brackets
+    expect(result).not.toContain('&#x27;');
+    expect(result).not.toContain('&quot;');
+    expect(result).toContain("['field']");
+    expect(result).toContain('"value"');
+    expect(result).toBe(
+      'Subject: Query Help\nContent: How do I use [\'field\'] == "value" in APL?',
+    );
+  });
+
+  it('should handle mixed special characters', async () => {
+    const template = '{{message}}';
+    const context = {
+      message: '<script>alert("XSS")</script> & special chars: \', ", =, <, >',
+    };
+
+    const result = await handlebarsParse(template, { context });
+
+    // Should NOT escape HTML entities (we're generating for AI models, not HTML)
+    expect(result).not.toContain('&lt;');
+    expect(result).not.toContain('&gt;');
+    expect(result).not.toContain('&quot;');
+    expect(result).not.toContain('&#x27;');
+    expect(result).not.toContain('&amp;');
+
+    // Should preserve original characters
+    expect(result).toBe('<script>alert("XSS")</script> & special chars: \', ", =, <, >');
+  });
+
+  it('should handle nested conditionals with special characters', async () => {
+    const template = '{{#if hasQuery}}Query: {{query}}{{else}}No query{{/if}}';
+    const context = {
+      hasQuery: true,
+      query: "['dataset'] | where ['field'] == 'value'",
+    };
+
+    const result = await handlebarsParse(template, { context });
+
+    expect(result).not.toContain('&#x27;');
+    expect(result).toBe("Query: ['dataset'] | where ['field'] == 'value'");
+  });
+});


### PR DESCRIPTION
Context: https://watchlyhq.slack.com/archives/C08SUPFCQ7J/p1760523133698819.

Prevents odd escaping:

![tempImageOybc0M](https://github.com/user-attachments/assets/15be2920-c7e2-41b3-9217-8df572965fb1)
![tempImageSsJMzy](https://github.com/user-attachments/assets/8be7de30-030d-4554-8f67-f4c2c891f397)
