### PR TITLE
feat: add `--list` flag

### DIFF
--- a/packages/ai/src/cli/commands/eval.command.ts
+++ b/packages/ai/src/cli/commands/eval.command.ts
@@ -27,7 +27,7 @@ export const loadEvalCommand = (program: Command, flagOverrides: FlagOverrides =
       .option('-u, --url <AXIOM URL>', 'axiom url', process.env.AXIOM_URL ?? 'https://api.axiom.co')
       .option('-b, --baseline <BASELINE ID>', 'id of baseline evaluation to compare against')
       .option('--debug', 'run locally without sending to Axiom or loading baselines', false)
-      .option('--collect-only', 'list evaluations and test cases without running them', false)
+      .option('--list', 'list evaluations and test cases without running them', false)
       .action(async (target: string, options) => {
         try {
           // Propagate debug mode to processes that we can't reach otherwise (e.g., reporter, app instrumentation)
@@ -86,7 +86,7 @@ export const loadEvalCommand = (program: Command, flagOverrides: FlagOverrides =
               exclude,
               testNamePattern,
               debug: options.debug,
-              collectOnly: options.collectOnly,
+              list: options.list,
               overrides: flagOverrides,
               config,
               runId,

--- a/packages/ai/src/evals/eval.ts
+++ b/packages/ai/src/evals/eval.ts
@@ -39,7 +39,7 @@ declare module 'vitest' {
   export interface ProvidedContext {
     baseline?: string;
     debug?: boolean;
-    collectOnly?: boolean;
+    list?: boolean;
     overrides?: Record<string, any>;
     axiomConfig?: ResolvedAxiomConfig;
     runId: string;
@@ -158,7 +158,7 @@ async function registerEval<
   // check if user passed a specific baseline id to the CLI
   const baselineId = inject('baseline');
   const isDebug = inject('debug');
-  const isCollectOnly = inject('collectOnly');
+  const isList = inject('list');
   const injectedOverrides = inject('overrides');
   const axiomConfig = inject('axiomConfig');
   const runId = inject('runId');
@@ -170,7 +170,7 @@ async function registerEval<
   const timeoutMs = opts.timeout ?? axiomConfig?.eval.timeoutMs;
 
   const instrumentationReady =
-    !isDebug && !isCollectOnly ? ensureInstrumentationInitialized(axiomConfig) : Promise.resolve();
+    !isDebug && !isList ? ensureInstrumentationInitialized(axiomConfig) : Promise.resolve();
 
   const result = await describe(
     evalName,
@@ -218,7 +218,7 @@ async function registerEval<
         // - Actual errors (`!resp.ok` etc) are treated as instrumentation failures
         // - Nullish results just mean no baseline exists (first run or not found)
         try {
-          if (!isDebug && !isCollectOnly) {
+          if (!isDebug && !isList) {
             baseline = baselineId
               ? await findEvaluationCases(baselineId, axiomConfig)
               : await findBaseline(evalName, axiomConfig);

--- a/packages/ai/src/evals/run-vitest.ts
+++ b/packages/ai/src/evals/run-vitest.ts
@@ -44,7 +44,7 @@ export const runVitest = async (
     exclude?: string[];
     testNamePattern?: RegExp;
     debug?: boolean;
-    collectOnly?: boolean;
+    list?: boolean;
     overrides?: Record<string, any>;
     config: ResolvedAxiomConfig;
     runId: string;
@@ -53,9 +53,9 @@ export const runVitest = async (
   // Store config globally so reporters can access it
   setAxiomConfig(opts.config);
 
-  // Initialize instrumentation explicitly based on debug or collect-only flag
+  // Initialize instrumentation explicitly based on debug or list flag
   await initInstrumentation({
-    enabled: !opts.debug && !opts.collectOnly,
+    enabled: !opts.debug && !opts.list,
     config: opts.config,
   });
 
@@ -72,8 +72,8 @@ export const runVitest = async (
     console.log(c.bgWhite(c.blackBright(' Debug mode enabled ')));
   }
 
-  if (opts.collectOnly) {
-    console.log(c.bgWhite(c.blackBright(' Collect-only mode ')));
+  if (opts.list) {
+    console.log(c.bgWhite(c.blackBright(' List mode ')));
   }
 
   const vi = await createVitest('test', {
@@ -95,15 +95,15 @@ export const runVitest = async (
     provide: {
       baseline: opts.baseline,
       debug: opts.debug,
-      collectOnly: opts.collectOnly,
+      list: opts.list,
       overrides: opts.overrides,
       axiomConfig: providedConfig,
       runId: opts.runId,
     },
   });
 
-  // Collect-only mode: just list tests without running them
-  if (opts.collectOnly) {
+  // List mode: just list tests without running them
+  if (opts.list) {
     const result = await vi.collect();
     printCollectedEvals(result, dir || process.cwd());
     await vi.close();


### PR DESCRIPTION
## Background

Glob patterns are notoriously finicky, so it's nice to have a feature that lets the user find out which evals a certain command would run. Especially since running evals both costs money and takes a nontrivial amount of time. 

This PR adds a `--list` flag that collects the evals to be run and prints them to the console.

The reason we don't use Vitest's built-in `list` is that its behavior doesn't make sense for us: each case prints a separate line!

Example output of stock `list` (two evals with two cases each)
```
src/lib/capabilities/classify-ticket/evaluations/ticket-classification.eval.ts
  spam-classification > case
  spam-classification > case

test/feature.eval.ts
  Basic-demo > case
  Basic-demo > case
```

So effectively we're just overriding what `list` prints.

(note: this PR also changes the block name from `evaluate: ${evalName}` to just `${evalName}`. this was not being used anywhere else anymore afaik, and for this it makes our output look nicer.)

## Demo

<img width="1010" height="530" alt="CleanShot 2025-11-10 at 20 16 04@2x" src="https://github.com/user-attachments/assets/e33ba585-bccc-44b5-ad38-c5bd441a61e1" />
