### PR TITLE
feat(AI-65): move Eval() to GA

### DIFF
--- a/examples/example-evals-nextjs/src/lib/capabilities/classify-ticket/evaluations/ticket-classification.eval.ts
+++ b/examples/example-evals-nextjs/src/lib/capabilities/classify-ticket/evaluations/ticket-classification.eval.ts
@@ -1,11 +1,11 @@
-import { experimental_Eval as Eval, Scorer } from 'axiom/ai/evals';
+import { Eval, Scorer } from 'axiom/ai/evals';
 import { jaccardResponseScorer, spamClassificationScorer } from '../../../scorers';
 import { classifyTicketStep } from '../../../capabilities/classify-ticket/prompts';
 import { pickFlags } from '@/lib/app-scope';
 import { ExactMatch } from 'autoevals';
 
 const WrappedExactMatch = Scorer(
-  'Exact-match',
+  'exact-match',
   (args: {
     output: { response: string; category: string };
     expected: { response: string; category: string };

--- a/examples/example-evals-nextjs/test/feature.eval.ts
+++ b/examples/example-evals-nextjs/test/feature.eval.ts
@@ -1,4 +1,4 @@
-import { experimental_Eval as Eval, Scorer } from 'axiom/ai/evals';
+import { Eval, Scorer } from 'axiom/ai/evals';
 import { flag, fact, pickFlags } from '../src/lib/app-scope';
 
 const myFn = async (input: string, expected: string) => {
@@ -14,7 +14,7 @@ const myFn = async (input: string, expected: string) => {
 
 // an example of a custom scorer
 const ExactMatchScorer = Scorer(
-  'Exact-match',
+  'exact-match',
   ({ output, expected }: { output: string; expected: string }) => (output === expected ? 1 : 0),
 );
 

--- a/packages/ai/src/evals.ts
+++ b/packages/ai/src/evals.ts
@@ -1,10 +1,6 @@
-// Eval functionality - marked as UNSAFE as these APIs are experimental
-export { Eval as experimental_Eval } from './evals/eval';
-export type {
-  EvalTask as experimental_EvalTask,
-  EvalParams as experimental_EvalParams,
-} from './evals/eval.types';
-export { AxiomReporter as experimental_AxiomReporter } from './evals/reporter';
+export { Eval } from './evals/eval';
+export type { EvalTask, EvalParams } from './evals/eval.types';
+export { AxiomReporter } from './evals/reporter';
 
 export { withEvalContext, getEvalContext } from './evals/context/storage';
 export type { EvalContextData } from './evals/context/storage';

--- a/packages/ai/src/evals/eval.ts
+++ b/packages/ai/src/evals/eval.ts
@@ -56,14 +56,13 @@ const createVersionId = customAlphabet('0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ', 1
  * This function sets up a complete evaluation pipeline that will run your {@link EvalTask}
  * against a dataset, score the results, and provide detailed {@link EvalCaseReport} reporting.
  *
- * @experimental This API is experimental and may change in future versions.
  *
  * @param name - Human-readable name for the evaluation suite
  * @param params - {@link EvalParams} configuration parameters for the evaluation
  *
  * @example
  * ```typescript
- * import { experimental_Eval as Eval } from 'axiom/ai/evals';
+ * import { Eval } from 'axiom/ai/evals';
  *
  * Eval('Text Generation Quality', {
  *   data: async () => [

--- a/packages/ai/src/evals/eval.types.ts
+++ b/packages/ai/src/evals/eval.types.ts
@@ -29,7 +29,6 @@ export type OutputOf<TaskFn extends (...args: any) => any> = TaskFn extends (
  * Used with {@link EvalParams} to define the task that will be evaluated against a dataset.
  * The task output will be scored by functions defined in {@link EvalParams.scorers}.
  *
- * @experimental This API is experimental and may change in future versions.
  *
  * @param input - The input data to process
  * @param expected - The expected output for comparison/validation
@@ -58,7 +57,6 @@ export type EvalTask<
 /**
  * Record type representing a single data point in an evaluation dataset.
  *
- * @experimental This API is experimental and may change in future versions.
  */
 export type CollectionRecord<
   TInput extends string | Record<string, any>,
@@ -78,7 +76,6 @@ export type CollectionRecord<
  * Used with {@link Eval} to define how an evaluation should be executed.
  * Results are captured in {@link EvalReport} format.
  *
- * @experimental This API is experimental and may change in future versions.
  */
 export type EvalParams<
   TInput extends string | Record<string, any>,
@@ -193,7 +190,6 @@ export type Task = {
  * Generated for each test case when running {@link Eval} with {@link EvalParams}.
  * Contains all {@link Score} results and execution metadata.
  *
- * @experimental This API is experimental and may change in future versions.
  */
 export type EvalCaseReport = {
   /** Order/index of this case in the evaluation suite */


### PR DESCRIPTION
- Take evals out of experimental, and make it GA for public preview.