### PR TITLE
feat(cli): add shorthands for auth status and switch

### DIFF
--- a/packages/ai/src/cli/commands/auth-status.command.ts
+++ b/packages/ai/src/cli/commands/auth-status.command.ts
@@ -51,20 +51,22 @@ export async function statusCommand(): Promise<void> {
   }
 }
 
-export function loadAuthStatusCommand(program: Command): void {
-  program
-    .command('status')
-    .description('Check authentication status for all profiles')
-    .action(async () => {
-      try {
-        await statusCommand();
-      } catch (error) {
-        if (error instanceof AxiomCLIError) {
-          console.error(`\n❌ Error: ${error.message}\n`);
-        } else {
-          console.error(`\n❌ Unexpected error: ${(error as Error).message}\n`);
+export function loadAuthStatusCommand(auth: Command, program: Command): void {
+  [auth, program].forEach((program) => {
+    program
+      .command('status')
+      .description('Check authentication status for all profiles')
+      .action(async () => {
+        try {
+          await statusCommand();
+        } catch (error) {
+          if (error instanceof AxiomCLIError) {
+            console.error(`\n❌ Error: ${error.message}\n`);
+          } else {
+            console.error(`\n❌ Unexpected error: ${(error as Error).message}\n`);
+          }
+          process.exit(1);
         }
-        process.exit(1);
-      }
-    });
+      });
+  });
 }

--- a/packages/ai/src/cli/commands/auth-switch.command.ts
+++ b/packages/ai/src/cli/commands/auth-switch.command.ts
@@ -79,21 +79,23 @@ export async function switchCommand(alias?: string): Promise<void> {
   console.log(`✓ Switched to profile: ${selectedAlias}\n`);
 }
 
-export function loadAuthSwitchCommand(program: Command): void {
-  program
-    .command('switch')
-    .description('Switch to a different profile')
-    .argument('[alias]', 'Profile alias to switch to')
-    .action(async (alias?: string) => {
-      try {
-        await switchCommand(alias);
-      } catch (error) {
-        if (error instanceof AxiomCLIError) {
-          console.error(`\n❌ Error: ${error.message}\n`);
-        } else {
-          console.error(`\n❌ Unexpected error: ${(error as Error).message}\n`);
+export function loadAuthSwitchCommand(auth: Command, root: Command): void {
+  [auth, root].forEach((program) => {
+    program
+      .command('switch')
+      .description('Switch to a different profile')
+      .argument('[alias]', 'Profile alias to switch to')
+      .action(async (alias?: string) => {
+        try {
+          await switchCommand(alias);
+        } catch (error) {
+          if (error instanceof AxiomCLIError) {
+            console.error(`\n❌ Error: ${error.message}\n`);
+          } else {
+            console.error(`\n❌ Unexpected error: ${(error as Error).message}\n`);
+          }
+          process.exit(1);
         }
-        process.exit(1);
-      }
-    });
+      });
+  });
 }

--- a/packages/ai/src/cli/commands/auth.command.ts
+++ b/packages/ai/src/cli/commands/auth.command.ts
@@ -9,6 +9,6 @@ export function loadAuthCommand(program: Command): void {
 
   loadAuthLoginCommand(auth, program);
   loadAuthLogoutCommand(auth, program);
-  loadAuthStatusCommand(auth);
-  loadAuthSwitchCommand(auth);
+  loadAuthStatusCommand(auth, program);
+  loadAuthSwitchCommand(auth, program);
 }


### PR DESCRIPTION
Adds a shorthand so that you can run
```bash
axiom status # instead of axiom auth status
axiom switch # instead of axiom auth switch
```