### PR TITLE
feat: if there is one eval in the run, navigate to the eval instance directly

### DIFF
--- a/packages/ai/src/evals/reporter.console-utils.ts
+++ b/packages/ai/src/evals/reporter.console-utils.ts
@@ -18,6 +18,7 @@ import { flattenObject } from '../util/dot-path';
 import type { AxiomConnectionResolvedConfig } from '../config/resolver';
 
 export type SuiteData = {
+  version: string;
   name: string;
   file: string;
   duration: string;
@@ -615,8 +616,17 @@ export function printFinalReport({
   const anyFailed = registrationStatus.some((s) => !s.registered);
 
   if (anyRegistered && orgId && config?.consoleEndpointUrl) {
-    logger('View full report:');
-    logger(`${config.consoleEndpointUrl}/${orgId}/ai-engineering/evaluations?runId=${runId}`);
+    if (suiteData.length === 1) {
+      const suite = suiteData[0];
+      const baselineParam = suite.baseline?.traceId ? `?baselineId=${suite.baseline.traceId}` : '';
+      logger('View eval result:');
+      logger(
+        `${config.consoleEndpointUrl}/${orgId}/ai-engineering/evaluations/${suite.name}/${suite.version}${baselineParam}`,
+      );
+    } else {
+      logger('View full report:');
+      logger(`${config.consoleEndpointUrl}/${orgId}/ai-engineering/evaluations?runId=${runId}`);
+    }
   } else if (isDebug) {
     logger(c.dim('Results not uploaded to Axiom (debug mode)'));
   } else {

--- a/packages/ai/src/evals/reporter.ts
+++ b/packages/ai/src/evals/reporter.ts
@@ -123,6 +123,7 @@ export class AxiomReporter implements Reporter {
     }
 
     this._suiteData.push({
+      version: meta.evaluation.version,
       name: meta.evaluation.name,
       file: relativePath,
       duration: durationSeconds + 's',


### PR DESCRIPTION
Before merging: confirm that we want to keep evals on `<axiom_url>/<org_id>/ai-engineering/evaluations/<eval_name>/<10_digit_eval_id>?baselineId=<baseline_trace_id>`, see: https://watchlyhq.slack.com/archives/C08SUPFCQ7J/p1764345135217149

<img width="812" height="568" alt="CleanShot 2025-11-28 at 22 54 30@2x" src="https://github.com/user-attachments/assets/ecb3bbe4-3796-42ba-bfbe-380efed44c62" />
