### PR TITLE
feat: put `eval.case.metadata` on case span

### DIFF
--- a/packages/ai/src/evals/eval.ts
+++ b/packages/ai/src/evals/eval.ts
@@ -458,6 +458,7 @@ async function registerEval<
                 typeof data.input === 'string' ? data.input : JSON.stringify(data.input),
               [Attr.Eval.Case.Expected]:
                 typeof data.expected === 'string' ? data.expected : JSON.stringify(data.expected),
+              [Attr.Eval.Case.Metadata]: data.metadata ? JSON.stringify(data.metadata) : undefined,
               // user info
               [Attr.Eval.User.Name]: user?.name,
               [Attr.Eval.User.Email]: user?.email,
@@ -597,6 +598,7 @@ async function registerEval<
                 expected: data.expected,
                 input: data.input,
                 output: output,
+                metadata: data.metadata,
                 scores,
                 status: 'success',
                 errors: [],
@@ -635,6 +637,7 @@ async function registerEval<
                 expected: data.expected,
                 input: data.input,
                 output: String(e),
+                metadata: data.metadata,
                 scores: failedScores,
                 status: 'fail',
                 errors: [error],

--- a/packages/ai/src/evals/eval.types.ts
+++ b/packages/ai/src/evals/eval.types.ts
@@ -190,6 +190,8 @@ export type EvalCaseReport = {
   output: string | Record<string, any>;
   /** Expected output for comparison */
   expected: string | Record<string, any>;
+  /** Optional metadata for the case */
+  metadata?: Record<string, any>;
   /** Array of {@link Score} results from all scorers that were run */
   scores: Record<string, ScoreWithName>;
   /** Any errors that occurred during evaluation */


### PR DESCRIPTION
It's part of the type on an eval's `data`, so we should record it.

Future: strip out non serializable keys recursively