### PR TITLE
feat: more improvements to feedback types

### DIFF
--- a/packages/ai/src/feedback.ts
+++ b/packages/ai/src/feedback.ts
@@ -136,8 +136,8 @@ type FeedbackParamsBoolean = Omit<FeedbackInputBoolean, 'kind'>;
 /** Parameters for creating a text feedback (excludes `kind`). */
 type FeedbackParamsText = Omit<FeedbackInputText, 'kind'>;
 
-/** Parameters for creating a signal feedback (excludes `kind`). */
-type FeedbackParamsSignal = Omit<FeedbackInputSignal, 'kind'>;
+/** Parameters for creating a signal feedback (excludes `kind` and `value`). */
+type FeedbackParamsSignal = Omit<FeedbackInputSignal, 'kind' | 'value'>;
 
 /** Base parameters shared by all feedback types (name, message, category, metadata). */
 type FeedbackParamsBase = FeedbackInputBase;
@@ -277,7 +277,7 @@ const boolFeedback = (input: FeedbackParamsBoolean): FeedbackInputBoolean =>
 const textFeedback = (input: FeedbackParamsText): FeedbackInputText => withKind(input, 'text');
 
 const signalFeedback = (input: FeedbackParamsSignal): FeedbackInputSignal =>
-  withKind(input, 'signal');
+  withKind({ ...input, value: null }, 'signal');
 
 /**
  * Helper functions for creating feedback input objects.

--- a/packages/ai/test/feedback/feedback.test.ts
+++ b/packages/ai/test/feedback/feedback.test.ts
@@ -77,7 +77,7 @@ describe('Feedback helpers', () => {
   describe('signal', () => {
     it('should return signal feedback', () => {
       const result = Feedback.signal({ name: 'clicked' });
-      expect(result).toEqual({ kind: 'signal', name: 'clicked' });
+      expect(result).toEqual({ kind: 'signal', name: 'clicked', value: null });
     });
   });
 
@@ -273,6 +273,7 @@ describe('createFeedbackClient', () => {
       },
       name: 'clicked',
       schemaUrl: 'https://axiom.co/ai/schemas/0.0.2',
+      value: null,
     });
   });
 


### PR DESCRIPTION
- FeedbackEvent now includes _time: string to match what Axiom returns from queries.
- Added `value: null` to FeedbackCoreSignal so all event kinds have a value property, this is more explicit and makes the types nicer to work with for consumers