### PR TITLE
feat(feedback): return noop client when config is missing

### DIFF
--- a/packages/ai/src/feedback.ts
+++ b/packages/ai/src/feedback.ts
@@ -176,6 +176,10 @@ type FeedbackClient = {
   readonly sendFeedback: SendFeedbackFn;
 };
 
+const createNoopFeedbackClient = (): FeedbackClient => ({
+  sendFeedback: async () => {},
+});
+
 /**
  * Creates a feedback client for sending user feedback to Axiom.
  *
@@ -192,6 +196,12 @@ const createFeedbackClient = (
   config: FeedbackConfig,
   settings?: FeedbackSettings,
 ): FeedbackClient => {
+  if (!config.token || !config.dataset) {
+    const missing = [!config.token && 'token', !config.dataset && 'dataset'].filter(Boolean);
+    console.error(`[Feedback] Missing config: ${missing.join(', ')}. Feedback disabled.`);
+    return createNoopFeedbackClient();
+  }
+
   const baseUrl = config.url ?? 'https://api.axiom.co';
   const url = `${baseUrl}${getSuffix(baseUrl, config.dataset)}`;
 

--- a/packages/ai/test/feedback/feedback.test.ts
+++ b/packages/ai/test/feedback/feedback.test.ts
@@ -352,3 +352,42 @@ describe('createFeedbackClient', () => {
     });
   });
 });
+
+describe('createFeedbackClient with missing config', () => {
+  it('should return noop client and log error when token is missing', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const client = createFeedbackClient({ token: '', dataset: 'test-dataset' });
+
+    expect(consoleError).toHaveBeenCalledWith(
+      '[Feedback] Missing config: token. Feedback disabled.',
+    );
+
+    await client.sendFeedback(
+      { traceId: 'trace-123', capability: 'test-cap' },
+      Feedback.thumbUp({ name: 'rating' }),
+    );
+
+    expect(consoleError).toHaveBeenCalledTimes(1);
+    consoleError.mockRestore();
+  });
+
+  it('should return noop client and log error when dataset is missing', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    createFeedbackClient({ token: 'test-token', dataset: '' });
+
+    expect(consoleError).toHaveBeenCalledWith(
+      '[Feedback] Missing config: dataset. Feedback disabled.',
+    );
+    consoleError.mockRestore();
+  });
+
+  it('should return noop client and log error when both are missing', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    createFeedbackClient({ token: '', dataset: '' });
+
+    expect(consoleError).toHaveBeenCalledWith(
+      '[Feedback] Missing config: token, dataset. Feedback disabled.',
+    );
+    consoleError.mockRestore();
+  });
+});


### PR DESCRIPTION
`createFeedbackClient` now gracefully handles missing `token` or `dataset` by logging an error at creation time and returning a silent noop client. This prevents runtime errors when users pass `process.env.VAR!` that resolves to undefined.