### PR TITLE
fix: eval output gets json.stringified even if it's a string already

### DIFF
--- a/packages/ai/src/evals/eval.ts
+++ b/packages/ai/src/evals/eval.ts
@@ -756,8 +756,7 @@ const runTask = async <
           const duration = Math.round(performance.now() - start);
           // set task output
           taskSpan.setAttributes({
-            [Attr.Eval.Task.Output]:
-              typeof output === 'string' ? output : JSON.stringify(output),
+            [Attr.Eval.Task.Output]: typeof output === 'string' ? output : JSON.stringify(output),
           });
 
           // Get out-of-scope flags from the evaluation context


### PR DESCRIPTION
`eval.task.output` always called `JSON.stringify(output)`, causing string outputs like `spam` to be stored as `"spam"` while `eval.case.expected` correctly preserved strings as-is.