### PR TITLE
feat(ai): add online evaluations for production monitoring

### DIFF
--- a/examples/kitchen-sink/src/lib/capabilities/support-agent/categorize-messages.ts
+++ b/examples/kitchen-sink/src/lib/capabilities/support-agent/categorize-messages.ts
@@ -1,8 +1,9 @@
 import { flag } from '@/lib/app-scope';
 import { openai } from '@/lib/openai';
 import { generateText, ModelMessage } from 'ai';
-import { withSpan, wrapAISDKModel } from 'axiom/ai';
+import { withSpan, wrapAISDKModel, onlineEval } from 'axiom/ai';
 import z from 'zod';
+import { validCategoryScorer, formatConfidenceScorer } from './online-scorers';
 
 export const messageCategories = [
   'support',
@@ -18,29 +19,46 @@ export const categorizeMessage = async (messages: ModelMessage[]): Promise<Messa
   const modelName = flag('supportAgent.categorizeMessage.model');
   const model = wrapAISDKModel(openai(modelName));
 
-  return await withSpan({ capability: 'support-agent', step: 'categorize-message' }, async () => {
-    const text = `<instructions>
+  // Extract the last user message for online evaluation input
+  const lastUserMessage = messages.filter((m) => m.role === 'user').pop();
+  const evalInput = lastUserMessage?.content ?? '';
+
+  return await withSpan(
+    { capability: 'support-agent', step: 'categorize-message' },
+    async () => {
+      const text = `<instructions>
 Please analyze the following series of messages. For the final user message, classify it as one of the following categories: ${messageCategories.join(', ')}.
-    
+
 Reply only with the category name.
 </instructions>
 <messages>
 ${messages.map((msg) => `${msg.role}: ${msg.content}`).join('\n')}
-</messages>    
+</messages>
     `;
-    const response = await generateText({
-      model: model,
-      messages: [{ role: 'system', content: text }],
-    });
+      const response = await generateText({
+        model: model,
+        messages: [{ role: 'system', content: text }],
+      });
 
-    const trimmed = response.text.trim().toLowerCase();
+      const trimmed = response.text.trim().toLowerCase();
 
-    const parsed = messageCategoriesSchema.safeParse(trimmed);
+      const parsed = messageCategoriesSchema.safeParse(trimmed);
 
-    if (parsed.error) {
-      return 'unknown';
-    }
+      const result = parsed.error ? 'unknown' : parsed.data;
 
-    return parsed.data;
-  });
+      // Online evaluation: monitor classification quality in production
+      // Active span is auto-linked. Fire-and-forget — doesn't block response.
+      void onlineEval(
+        { capability: 'support-agent', step: 'categorize-message' },
+        {
+          input: evalInput,
+          output: result,
+          scorers: [validCategoryScorer, formatConfidenceScorer],
+          sampling: { rate: 0.1 }, // Evaluate 10% of production traffic
+        },
+      );
+
+      return result;
+    },
+  );
 };

--- a/examples/kitchen-sink/src/lib/capabilities/support-agent/online-scorers.ts
+++ b/examples/kitchen-sink/src/lib/capabilities/support-agent/online-scorers.ts
@@ -1,0 +1,134 @@
+/**
+ * Online evaluation scorers for production monitoring.
+ *
+ * These scorers run on live traffic (not against expected values)
+ * to monitor model quality in production. They are reference-free,
+ * meaning they only see input and output, not ground truth.
+ *
+ * Usage with onlineEval:
+ * ```ts
+ * const result = await withSpan(
+ *   { capability: 'support-agent', step: 'categorize-message' },
+ *   async () => {
+ *     const response = await generateText({ ... });
+ *
+ *     // Fire-and-forget — active span is auto-linked
+ *     void onlineEval(
+ *       { capability: 'support-agent', step: 'categorize-message' },
+ *       {
+ *         input: userMessage,
+ *         output: response.text,
+ *         scorers: [validCategoryScorer, confidenceScorer],
+ *         sampling: { rate: 0.1 },
+ *       }
+ *     );
+ *
+ *     return response.text;
+ *   },
+ * );
+ * ```
+ */
+
+import { Scorer } from 'axiom/ai';
+import { messageCategories, type MessageCategory } from './categorize-messages';
+
+/**
+ * Validates that the classification output is a known category.
+ *
+ * This scorer demonstrates returning a boolean Score with metadata.
+ * When score is a boolean, Scorer() automatically converts it to 1/0
+ * and sets metadata.is_boolean = true, while preserving your custom metadata.
+ *
+ * For simpler pass/fail checks without metadata, see isKnownCategoryScorer.
+ */
+export const validCategoryScorer = Scorer(
+  'valid-category',
+  ({ output }: { output: MessageCategory }) => {
+    const isValid = messageCategories.includes(output as (typeof messageCategories)[number]);
+    return {
+      score: isValid,
+      metadata: {
+        category: output,
+        validCategories: messageCategories,
+      },
+    };
+  },
+);
+
+/**
+ * Simple pass/fail check: is the output a known category?
+ *
+ * This scorer demonstrates the boolean return pattern.
+ * When you return true/false directly, Scorer() automatically:
+ * - Converts to score 1 (true) or 0 (false)
+ * - Sets metadata.is_boolean = true for downstream analysis
+ *
+ * Use this pattern for simple pass/fail checks without custom metadata.
+ */
+export const isKnownCategoryScorer = Scorer(
+  'is-known-category',
+  ({ output }: { output: MessageCategory }) => {
+    return messageCategories.includes(output as (typeof messageCategories)[number]);
+  },
+);
+
+/**
+ * Checks if the output looks like a single-word classification.
+ * High confidence if it's a clean, lowercase category name.
+ */
+export const formatConfidenceScorer = Scorer(
+  'format-confidence',
+  ({ output }: { output: MessageCategory }) => {
+    if (typeof output !== 'string') {
+      return { score: 0, metadata: { reason: 'not a string' } };
+    }
+
+    const trimmed = output.trim().toLowerCase();
+    const isSingleWord = !trimmed.includes(' ');
+    const isLowercase = trimmed === output;
+    const isClean = /^[a-z_]+$/.test(trimmed);
+
+    const score = (isSingleWord ? 0.4 : 0) + (isLowercase ? 0.3 : 0) + (isClean ? 0.3 : 0);
+
+    return {
+      score,
+      metadata: {
+        isSingleWord,
+        isLowercase,
+        isClean,
+      },
+    };
+  },
+);
+
+/**
+ * Example of a more sophisticated scorer that could call an external API
+ * or another model for evaluation (e.g., toxicity detection, helpfulness).
+ *
+ * This is a simplified mock - in production you might call:
+ * - OpenAI moderation API
+ * - Perspective API for toxicity
+ * - A fine-tuned evaluation model
+ */
+export const responseQualityScorer = Scorer(
+  'response-quality',
+  async ({ input, output }: { input: string; output: string }) => {
+    // Simulate an async quality check
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    // Simple heuristics (replace with real evaluation in production)
+    const hasContent = typeof output === 'string' && output.length > 0;
+    const notTooShort = typeof output === 'string' && output.length >= 3;
+    const notTooLong = typeof output === 'string' && output.length < 1000;
+
+    const score = (hasContent ? 0.5 : 0) + (notTooShort ? 0.25 : 0) + (notTooLong ? 0.25 : 0);
+
+    return {
+      score,
+      metadata: {
+        inputLength: typeof input === 'string' ? input.length : 0,
+        outputLength: typeof output === 'string' ? output.length : 0,
+      },
+    };
+  },
+);

--- a/examples/online-evals-comprehensive/.env-example
+++ b/examples/online-evals-comprehensive/.env-example
@@ -1,0 +1,4 @@
+AXIOM_TOKEN=your-axiom-token
+AXIOM_DATASET=your-dataset
+AXIOM_URL=https://api.axiom.co
+OPENAI_API_KEY=your-openai-api-key

--- a/examples/online-evals-comprehensive/.gitignore
+++ b/examples/online-evals-comprehensive/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.env

--- a/examples/online-evals-comprehensive/eslint.config.js
+++ b/examples/online-evals-comprehensive/eslint.config.js
@@ -1,0 +1,3 @@
+import { config } from '@repo/eslint-config';
+
+export default config;

--- a/examples/online-evals-comprehensive/instrumentation.ts
+++ b/examples/online-evals-comprehensive/instrumentation.ts
@@ -1,0 +1,62 @@
+import 'dotenv/config';
+import { trace } from '@opentelemetry/api';
+import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
+import { BatchSpanProcessor } from '@opentelemetry/sdk-trace-base';
+import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
+import { resourceFromAttributes } from '@opentelemetry/resources';
+import { ATTR_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
+import { initAxiomAI, RedactionPolicy } from 'axiom/ai';
+
+export function setupTelemetry(config: {
+  url: string;
+  token: string;
+  dataset: string;
+  serviceName?: string;
+}) {
+  const exporter = new OTLPTraceExporter({
+    url: `${config.url}/v1/traces`,
+    headers: {
+      Authorization: `Bearer ${config.token}`,
+      'X-Axiom-Dataset': config.dataset,
+    },
+  });
+
+  const processor = new BatchSpanProcessor(exporter, {
+    maxQueueSize: 2048,
+    maxExportBatchSize: 512,
+    scheduledDelayMillis: 5000,
+    exportTimeoutMillis: 30000,
+  });
+
+  const provider = new NodeTracerProvider({
+    resource: resourceFromAttributes({
+      [ATTR_SERVICE_NAME]: config.serviceName || 'online-evals-comprehensive',
+    }),
+    spanProcessors: [processor],
+  });
+
+  provider.register();
+  const tracer = trace.getTracer(config.serviceName || 'online-evals-comprehensive');
+
+  initAxiomAI({ tracer, redactionPolicy: RedactionPolicy.AxiomDefault });
+
+  return provider;
+}
+
+let provider: NodeTracerProvider | undefined;
+
+export function initializeTelemetry() {
+  provider = setupTelemetry({
+    url: process.env['AXIOM_URL'] || 'https://api.axiom.co',
+    token: process.env['AXIOM_TOKEN']!,
+    dataset: process.env['AXIOM_DATASET']!,
+    serviceName: 'online-evals-comprehensive',
+  });
+}
+
+export async function flushTelemetry() {
+  if (provider) {
+    await provider.forceFlush();
+    await provider.shutdown();
+  }
+}

--- a/examples/online-evals-comprehensive/online-evals-comprehensive.ts
+++ b/examples/online-evals-comprehensive/online-evals-comprehensive.ts
@@ -1,0 +1,206 @@
+/**
+ * Online Evaluations — Comprehensive Example
+ *
+ * Demonstrates all onlineEval patterns. Each eval span links to its
+ * originating generation span via an OTel span link — the link is the
+ * stable relationship, parent/child hierarchy is just a consequence of
+ * where onlineEval() is called.
+ *
+ * Because this is a short-lived script that flushes telemetry before
+ * exiting, we collect eval promises and drain them before shutdown.
+ * In a long-running server, use `void onlineEval(...)` fire-and-forget
+ * instead — there's no shutdown race.
+ *
+ * Patterns shown:
+ * 1. Inside withSpan (recommended) — active span auto-detected and linked
+ * 2. Deferred — outside withSpan with explicit link
+ * 3. Standalone — no withSpan context, manual link
+ * 4. Awaitable — await onlineEval() inline for short-lived processes
+ */
+
+import { generateObject, generateText } from 'ai';
+import { createOpenAI } from '@ai-sdk/openai';
+import { type SpanContext } from '@opentelemetry/api';
+import { withSpan, wrapAISDKModel, Scorer, onlineEval } from 'axiom/ai';
+import { z } from 'zod';
+import { initializeTelemetry, flushTelemetry } from './instrumentation';
+
+initializeTelemetry();
+
+const openai = createOpenAI({ apiKey: process.env['OPENAI_API_KEY']! });
+const model = wrapAISDKModel(openai('gpt-4o-mini'));
+
+// =============================================================================
+// Scorers
+// =============================================================================
+
+// Output-only scorer: checks response format. Cheap — fine at 100%.
+const formatScorer = Scorer('format', ({ output }: { output: string }) => {
+  const trimmed = output.trim();
+  return /[.!?]$/.test(trimmed) && !trimmed.includes('\n') && trimmed.length <= 200;
+});
+
+// Input+output LLM judge: evaluates if the response answers the question.
+// Expensive — use a lower sampling rate in production.
+const judgeModel = wrapAISDKModel(openai('gpt-4o-mini'));
+const relevanceScorer = Scorer(
+  'relevance',
+  async ({ input, output }: { input: string; output: string }) => {
+    const result = await generateObject({
+      model: judgeModel,
+      schema: z.object({
+        relevant: z.boolean().describe('Whether the response answers the question'),
+      }),
+      system: 'You evaluate if an AI response answers the user question.',
+      prompt: `Question: ${input}\n\nResponse: ${output}`,
+    });
+    return result.object.relevant;
+  },
+);
+
+// =============================================================================
+// Main
+// =============================================================================
+
+async function main() {
+  console.log('Online Evaluations — Comprehensive Example');
+  console.log('============================================\n');
+
+  // Collect eval promises so we can drain them before flushing telemetry.
+  // In a long-running server, you'd use `void onlineEval(...)` instead.
+  const pendingEvals: Promise<unknown>[] = [];
+
+  // ---------------------------------------------------------------------------
+  // Pattern 1: Inside withSpan (recommended default)
+  // ---------------------------------------------------------------------------
+  // Active span is auto-detected and linked. The eval span is naturally a
+  // child of the withSpan span.
+  const prompt1 = 'Tell me a fun fact about space in one sentence.';
+  console.log('Pattern 1: Inside withSpan');
+  console.log(`Prompt: "${prompt1}"`);
+
+  const result1 = await withSpan({ capability: 'demo', step: 'generate-fact' }, async () => {
+    const response = await generateText({
+      model,
+      messages: [{ role: 'user', content: prompt1 }],
+    });
+
+    // In a server: `void onlineEval(...)` — fire-and-forget is fine.
+    // Here we collect the promise because the script exits after flush.
+    pendingEvals.push(
+      onlineEval(
+        { capability: 'demo', step: 'generate-fact' },
+        { output: response.text, scorers: [formatScorer] },
+      ),
+    );
+
+    return response.text;
+  });
+
+  console.log(`Response: ${result1}\n`);
+
+  // ---------------------------------------------------------------------------
+  // Pattern 2: Deferred — outside withSpan with explicit link
+  // ---------------------------------------------------------------------------
+  // Capture span.spanContext() inside the callback, then call onlineEval()
+  // after withSpan returns. The eval span is root-level with a link back to
+  // the originating span.
+  const prompt2 = 'What is the capital of France?';
+  console.log('Pattern 2: Deferred with explicit link');
+  console.log(`Prompt: "${prompt2}"`);
+
+  let originCtx: SpanContext;
+  const result2 = await withSpan({ capability: 'demo', step: 'answer-question' }, async (span) => {
+    originCtx = span.spanContext();
+
+    const response = await generateText({
+      model,
+      messages: [{ role: 'user', content: prompt2 }],
+    });
+    return response.text;
+  });
+
+  // Called outside withSpan — explicit link connects eval to originating span.
+  // LLM judge at 50% sampling rate — tune down for expensive scorers in production.
+  pendingEvals.push(
+    onlineEval(
+      { capability: 'demo', step: 'answer-question', link: originCtx! },
+      {
+        input: prompt2,
+        output: result2,
+        scorers: [relevanceScorer],
+        sampling: { rate: 0.5 },
+      },
+    ),
+  );
+
+  console.log(`Response: ${result2}\n`);
+
+  // ---------------------------------------------------------------------------
+  // Pattern 3: Standalone — no withSpan context, manual link
+  // ---------------------------------------------------------------------------
+  // Use a previously stored SpanContext (e.g., from a database or message queue)
+  // to link an eval span to an originating span that ran in a different process
+  // or at a different time.
+  const prompt3 = 'Name a famous scientist.';
+  console.log('Pattern 3: Standalone with manual link');
+  console.log(`Prompt: "${prompt3}"`);
+
+  let storedCtx: SpanContext;
+  const result3 = await withSpan({ capability: 'demo', step: 'name-scientist' }, async (span) => {
+    storedCtx = span.spanContext();
+
+    const response = await generateText({
+      model,
+      messages: [{ role: 'user', content: prompt3 }],
+    });
+    return response.text;
+  });
+
+  console.log(`Response: ${result3}`);
+
+  // Simulate a later evaluation using a stored SpanContext.
+  // No active withSpan context here — the link is the only connection.
+  pendingEvals.push(
+    onlineEval(
+      { capability: 'demo', step: 'name-scientist', link: storedCtx! },
+      { output: result3, scorers: [formatScorer] },
+    ),
+  );
+
+  console.log();
+
+  // ---------------------------------------------------------------------------
+  // Pattern 4: Awaitable — for short-lived processes
+  // ---------------------------------------------------------------------------
+  // For CLI tools or serverless functions, await the eval inline to ensure
+  // spans are created before flushing telemetry.
+  const prompt4 = 'What color is the sky?';
+  console.log('Pattern 4: Awaitable (for CLI / serverless)');
+  console.log(`Prompt: "${prompt4}"`);
+
+  const result4 = await withSpan({ capability: 'demo', step: 'describe-sky' }, async () => {
+    const response = await generateText({
+      model,
+      messages: [{ role: 'user', content: prompt4 }],
+    });
+    return response.text;
+  });
+
+  // Await ensures eval completes before we flush.
+  await onlineEval(
+    { capability: 'demo', step: 'describe-sky' },
+    { output: result4, scorers: [formatScorer] },
+  );
+
+  console.log(`Response: ${result4}\n`);
+
+  // Drain any outstanding evals before shutting down the trace provider.
+  await Promise.allSettled(pendingEvals);
+
+  console.log('Done! Check your Axiom dashboard for evaluation results.');
+
+  await flushTelemetry();
+}
+
+main().catch(console.error);

--- a/examples/online-evals-comprehensive/package.json
+++ b/examples/online-evals-comprehensive/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "online-evals-comprehensive",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "npx tsx online-evals-comprehensive.ts",
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
+    "lint": "eslint './**/*.{js,ts}'",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@ai-sdk/openai": "^2.0.72",
+    "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.202.0",
+    "@opentelemetry/resources": "^2.0.1",
+    "@opentelemetry/sdk-trace-base": "^2.0.1",
+    "@opentelemetry/sdk-trace-node": "^2.0.1",
+    "@opentelemetry/semantic-conventions": "^1.38.0",
+    "ai": "^5.0.102",
+    "axiom": "workspace:*",
+    "dotenv": "^17.2.0",
+    "zod": "catalog:"
+  },
+  "devDependencies": {
+    "@repo/eslint-config": "workspace:*",
+    "@types/node": "^22.0.0",
+    "eslint": "catalog:",
+    "tsx": "^4.20.4",
+    "typescript": "catalog:"
+  }
+}

--- a/examples/online-evals-comprehensive/tsconfig.json
+++ b/examples/online-evals-comprehensive/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "lib": ["ES2020", "dom", "DOM.Iterable"],
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "moduleResolution": "bundler",
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "strict": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true,
+    "types": ["node"],
+    "noEmit": true
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/examples/online-evals-minimal/.env-example
+++ b/examples/online-evals-minimal/.env-example
@@ -1,0 +1,4 @@
+AXIOM_TOKEN=your-axiom-token
+AXIOM_DATASET=your-dataset
+AXIOM_URL=https://api.axiom.co
+OPENAI_API_KEY=your-openai-api-key

--- a/examples/online-evals-minimal/.gitignore
+++ b/examples/online-evals-minimal/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.env

--- a/examples/online-evals-minimal/eslint.config.js
+++ b/examples/online-evals-minimal/eslint.config.js
@@ -1,0 +1,3 @@
+import { config } from '@repo/eslint-config';
+
+export default config;

--- a/examples/online-evals-minimal/instrumentation.ts
+++ b/examples/online-evals-minimal/instrumentation.ts
@@ -1,0 +1,62 @@
+import 'dotenv/config';
+import { trace } from '@opentelemetry/api';
+import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
+import { BatchSpanProcessor } from '@opentelemetry/sdk-trace-base';
+import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
+import { resourceFromAttributes } from '@opentelemetry/resources';
+import { ATTR_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
+import { initAxiomAI, RedactionPolicy } from 'axiom/ai';
+
+export function setupTelemetry(config: {
+  url: string;
+  token: string;
+  dataset: string;
+  serviceName?: string;
+}) {
+  const exporter = new OTLPTraceExporter({
+    url: `${config.url}/v1/traces`,
+    headers: {
+      Authorization: `Bearer ${config.token}`,
+      'X-Axiom-Dataset': config.dataset,
+    },
+  });
+
+  const processor = new BatchSpanProcessor(exporter, {
+    maxQueueSize: 2048,
+    maxExportBatchSize: 512,
+    scheduledDelayMillis: 5000,
+    exportTimeoutMillis: 30000,
+  });
+
+  const provider = new NodeTracerProvider({
+    resource: resourceFromAttributes({
+      [ATTR_SERVICE_NAME]: config.serviceName || 'online-evals-minimal',
+    }),
+    spanProcessors: [processor],
+  });
+
+  provider.register();
+  const tracer = trace.getTracer(config.serviceName || 'online-evals-minimal');
+
+  initAxiomAI({ tracer, redactionPolicy: RedactionPolicy.AxiomDefault });
+
+  return provider;
+}
+
+let provider: NodeTracerProvider | undefined;
+
+export function initializeTelemetry() {
+  provider = setupTelemetry({
+    url: process.env['AXIOM_URL'] || 'https://api.axiom.co',
+    token: process.env['AXIOM_TOKEN']!,
+    dataset: process.env['AXIOM_DATASET']!,
+    serviceName: 'online-evals-minimal',
+  });
+}
+
+export async function flushTelemetry() {
+  if (provider) {
+    await provider.forceFlush();
+    await provider.shutdown();
+  }
+}

--- a/examples/online-evals-minimal/online-evals-minimal.ts
+++ b/examples/online-evals-minimal/online-evals-minimal.ts
@@ -1,0 +1,55 @@
+/**
+ * Online Evaluations — Minimal Example
+ *
+ * Demonstrates the simplest use of online evaluations: a single scorer
+ * running inside a withSpan callback. The active span is auto-detected
+ * and linked to the eval span.
+ *
+ * This example awaits onlineEval() because it's a short-lived script
+ * that flushes telemetry before exiting. In a long-running server,
+ * use `void onlineEval(...)` for fire-and-forget.
+ */
+
+import { generateText } from 'ai';
+import { createOpenAI } from '@ai-sdk/openai';
+import { withSpan, wrapAISDKModel, Scorer, onlineEval } from 'axiom/ai';
+import { initializeTelemetry, flushTelemetry } from './instrumentation';
+
+initializeTelemetry();
+
+const openai = createOpenAI({ apiKey: process.env['OPENAI_API_KEY']! });
+const model = wrapAISDKModel(openai('gpt-4o-mini'));
+
+// Output-only scorer: checks if the response is a well-formed single sentence.
+const formatScorer = Scorer('format', ({ output }: { output: string }) => {
+  const trimmed = output.trim();
+  return /[.!?]$/.test(trimmed) && !trimmed.includes('\n') && trimmed.length <= 200;
+});
+
+async function main() {
+  const prompt = 'Tell me a fun fact about space in one sentence.';
+  console.log(`Prompt: "${prompt}"`);
+
+  const result = await withSpan({ capability: 'demo', step: 'generate-fact' }, async () => {
+    const response = await generateText({
+      model,
+      messages: [{ role: 'user', content: prompt }],
+    });
+
+    // Await ensures the eval completes before flushTelemetry() shuts down.
+    // In a long-running server, use `void onlineEval(...)` instead.
+    await onlineEval(
+      { capability: 'demo', step: 'generate-fact' },
+      { output: response.text, scorers: [formatScorer] },
+    );
+
+    return response.text;
+  });
+
+  console.log(`Response: ${result}`);
+  console.log('\nDone! Check your Axiom dashboard for evaluation results.');
+
+  await flushTelemetry();
+}
+
+main().catch(console.error);

--- a/examples/online-evals-minimal/package.json
+++ b/examples/online-evals-minimal/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "online-evals-minimal",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "npx tsx online-evals-minimal.ts",
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
+    "lint": "eslint './**/*.{js,ts}'",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@ai-sdk/openai": "^2.0.72",
+    "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.202.0",
+    "@opentelemetry/resources": "^2.0.1",
+    "@opentelemetry/sdk-trace-base": "^2.0.1",
+    "@opentelemetry/sdk-trace-node": "^2.0.1",
+    "@opentelemetry/semantic-conventions": "^1.38.0",
+    "ai": "^5.0.102",
+    "axiom": "workspace:*",
+    "dotenv": "^17.2.0"
+  },
+  "devDependencies": {
+    "@repo/eslint-config": "workspace:*",
+    "@types/node": "^22.0.0",
+    "eslint": "catalog:",
+    "tsx": "^4.20.4",
+    "typescript": "catalog:"
+  }
+}

--- a/examples/online-evals-minimal/tsconfig.json
+++ b/examples/online-evals-minimal/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "lib": ["ES2020", "dom", "DOM.Iterable"],
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "moduleResolution": "bundler",
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "strict": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true,
+    "types": ["node"],
+    "noEmit": true
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -3,6 +3,7 @@
 Axiom AI SDK provides
 - an API to wrap your AI calls with observability instrumentation.
 - offline evals
+- online evals
 
 ## Install
 

--- a/packages/ai/src/evals/scorer.factory.ts
+++ b/packages/ai/src/evals/scorer.factory.ts
@@ -28,9 +28,10 @@ type Simplify<T> = { [K in keyof T]: T[K] } & {};
  */
 export function createScorer<
   TArgs extends Record<string, any> = {},
-  TInput = TArgs extends { input: infer I } ? I : unknown,
-  TExpected = TArgs extends { expected: infer E } ? Exclude<E, undefined> : unknown,
-  TOutput = TArgs extends { output: infer O } ? Exclude<O, undefined> : never,
+  // Use tuple wrapping to prevent distributive conditional types
+  TInput = [TArgs] extends [{ input: infer I }] ? I : unknown,
+  TExpected = [TArgs] extends [{ expected: infer E }] ? Exclude<E, undefined> : unknown,
+  TOutput = [TArgs] extends [{ output: infer O }] ? Exclude<O, undefined> : never,
   TExtra extends Record<string, any> = Simplify<
     Omit<TArgs, 'input' | 'expected' | 'output' | 'trialIndex'>
   >,
@@ -48,7 +49,7 @@ export function createScorer<
    * Optional configuration for the scorer, including aggregation for trials.
    */
   options?: ScorerOptions,
-): TOutput extends never ? never : Scorer<TInput, TExpected, TOutput, TExtra> {
+): [TOutput] extends [never] ? never : Scorer<TInput, TExpected, TOutput, TExtra> {
   const normalizeScore = (res: number | boolean | Score): Score => {
     if (typeof res === 'number') {
       return { score: res };
@@ -102,5 +103,5 @@ export function createScorer<
     });
   }
 
-  return scorer as TOutput extends never ? never : Scorer<TInput, TExpected, TOutput, TExtra>;
+  return scorer as [TOutput] extends [never] ? never : Scorer<TInput, TExpected, TOutput, TExtra>;
 }

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -5,6 +5,10 @@
 export * from './otel/initAxiomAI';
 export * from './otel/vercel';
 export * from './otel/withSpan';
+export type { EvalSampling, ScorerResult } from './online-evals';
+export { onlineEval } from './online-evals';
+export { createScorer, createScorer as Scorer } from './evals/scorer.factory';
+export type { Score, Scorer as ScorerType } from './evals/scorers';
 export * from './otel/wrapTool';
 export * from './otel/middleware';
 export { type AxiomAIRedactionPolicy, RedactionPolicy } from './otel/utils/redaction';

--- a/packages/ai/src/online-evals/executor.ts
+++ b/packages/ai/src/online-evals/executor.ts
@@ -1,0 +1,68 @@
+import { context, trace, SpanStatusCode, type Span } from '@opentelemetry/api';
+import type { ScorerResult } from './types';
+import type { ScorerLike } from '../evals/scorers';
+import { Attr } from '../otel/semconv/attributes';
+
+/**
+ * Executes a single scorer and returns the result.
+ */
+export async function executeScorer<TInput, TOutput>(
+  scorer: ScorerLike<TInput, unknown, TOutput>,
+  input: TInput | undefined,
+  output: TOutput,
+  parentSpan: Span,
+): Promise<ScorerResult> {
+  const scorerName = (scorer as { name?: string }).name || 'unknown';
+
+  const tracer = trace.getTracer('axiom-ai');
+  const parentContext = trace.setSpan(context.active(), parentSpan);
+
+  return context.with(parentContext, async () => {
+    const scorerSpan = tracer.startSpan(`eval ${scorerName}`);
+
+    try {
+      scorerSpan.setAttributes({
+        [Attr.GenAI.Operation.Name]: 'eval.score',
+        [Attr.Eval.Score.Name]: scorerName,
+        [Attr.Eval.Tags]: JSON.stringify(['online']),
+      });
+
+      const result = await scorer({
+        input,
+        output,
+      });
+
+      const attrs: Record<string, string | number | boolean | undefined> = {
+        [Attr.Eval.Score.Value]: result.score ?? undefined,
+      };
+
+      if (result.metadata && Object.keys(result.metadata).length > 0) {
+        attrs[Attr.Eval.Score.Metadata] = JSON.stringify(result.metadata);
+      }
+
+      scorerSpan.setAttributes(attrs);
+      scorerSpan.setStatus({ code: SpanStatusCode.OK });
+
+      return {
+        name: scorerName,
+        score: result,
+      };
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+
+      scorerSpan.recordException(error);
+      scorerSpan.setStatus({
+        code: SpanStatusCode.ERROR,
+        message: error.message,
+      });
+
+      return {
+        name: scorerName,
+        score: { score: null, metadata: { error: error.message } },
+        error: error.message,
+      };
+    } finally {
+      scorerSpan.end();
+    }
+  });
+}

--- a/packages/ai/src/online-evals/index.ts
+++ b/packages/ai/src/online-evals/index.ts
@@ -1,0 +1,2 @@
+export type { EvalSampling, ScorerResult } from './types';
+export { onlineEval } from './onlineEval';

--- a/packages/ai/src/online-evals/onlineEval.ts
+++ b/packages/ai/src/online-evals/onlineEval.ts
@@ -1,0 +1,162 @@
+import { context, trace, SpanStatusCode, type SpanContext } from '@opentelemetry/api';
+import type { ScorerLike } from '../evals/scorers';
+import type { EvalSampling, ScorerResult } from './types';
+import { executeScorer } from './executor';
+
+/**
+ * Metadata for categorizing online evaluations.
+ */
+type OnlineEvalMeta = {
+  /** High-level capability being evaluated (e.g., 'qa', 'summarization') */
+  capability: string;
+  /** Specific step within the capability (e.g., 'answer', 'extract') */
+  step?: string;
+  /**
+   * Explicit SpanContext to link the eval span to the originating generation span.
+   * When omitted, the active span's context is used automatically.
+   * Use this for deferred evaluation when onlineEval is called after the
+   * originating span has completed.
+   */
+  link?: SpanContext;
+};
+
+/**
+ * Options for online evaluation.
+ */
+type OnlineEvalOptions<TInput, TOutput> = {
+  /** Input to pass to scorers (optional - only needed for input+output scorers) */
+  input?: TInput;
+  /** Output to evaluate */
+  output: TOutput;
+  /** Scorers to run (not mutated) */
+  scorers: readonly ScorerLike<TInput, unknown, TOutput>[];
+  /** Optional sampling configuration */
+  sampling?: EvalSampling;
+};
+
+/**
+ * Determines if evaluation should run based on sampling configuration.
+ */
+function shouldSample(sampling?: EvalSampling): boolean {
+  if (!sampling) return true;
+  if (sampling.rate >= 1) return true;
+  if (sampling.rate <= 0) return false;
+  return Math.random() < sampling.rate;
+}
+
+/**
+ * Run online evaluation scorers against production outputs.
+ *
+ * Returns a promise that resolves to scorer results. Use `void onlineEval(...)`
+ * for fire-and-forget, or `await onlineEval(...)` when you need to wait for
+ * completion (e.g., before flushing telemetry in short-lived processes).
+ *
+ * Each eval span links back to the originating generation span via an
+ * OpenTelemetry span link. Parent/child hierarchy follows natural context
+ * propagation — inside `withSpan` the eval is a child, outside it depends
+ * on the active context.
+ *
+ * ## Usage Patterns
+ *
+ * **Inside withSpan (recommended):**
+ * Active span is automatically detected and linked.
+ * ```ts
+ * await withSpan({ capability: 'qa', step: 'answer' }, async () => {
+ *   const response = await generateText({ ... });
+ *   void onlineEval(
+ *     { capability: 'qa', step: 'answer' },
+ *     { output: response.text, scorers: [formatScorer] }
+ *   );
+ *   return response.text;
+ * });
+ * ```
+ *
+ * **Deferred evaluation with explicit link:**
+ * Pass the originating span's context for linking when evaluating later.
+ * ```ts
+ * let spanCtx: SpanContext;
+ * const result = await withSpan({ ... }, async (span) => {
+ *   spanCtx = span.spanContext();
+ *   return await generateText({ ... });
+ * });
+ * void onlineEval({ ..., link: spanCtx }, { output: result, scorers });
+ * ```
+ *
+ * **Awaiting for flush (short-lived processes):**
+ * ```ts
+ * await onlineEval({ ... }, { output, scorers });
+ * await flushTelemetry();
+ * ```
+ *
+ * @param meta - Evaluation metadata for categorization
+ * @param meta.capability - High-level capability being evaluated
+ * @param meta.step - Optional step within the capability
+ * @param meta.link - Optional SpanContext to link to (auto-detected if omitted)
+ * @param options - Evaluation configuration
+ * @param options.input - Input to pass to scorers
+ * @param options.output - Output to evaluate
+ * @param options.scorers - Scorers to run
+ * @param options.sampling - Optional sampling configuration
+ * @returns Promise resolving to scorer results
+ */
+export function onlineEval<TInput, TOutput>(
+  meta: OnlineEvalMeta,
+  options: OnlineEvalOptions<TInput, TOutput>,
+): Promise<ScorerResult[]> {
+  if (options.scorers.length === 0) {
+    return Promise.resolve([]);
+  }
+
+  if (!shouldSample(options.sampling)) {
+    return Promise.resolve([]);
+  }
+
+  const linkSpanContext = meta.link ?? trace.getSpan(context.active())?.spanContext();
+
+  return executeOnlineEvalInternal(meta, options, linkSpanContext);
+}
+
+async function executeOnlineEvalInternal<TInput, TOutput>(
+  meta: OnlineEvalMeta,
+  options: OnlineEvalOptions<TInput, TOutput>,
+  linkSpanContext: SpanContext | undefined,
+): Promise<ScorerResult[]> {
+  const tracer = trace.getTracer('axiom-ai');
+
+  const spanName = meta.step ? `eval ${meta.capability}/${meta.step}` : `eval ${meta.capability}`;
+
+  const evalSpan = tracer.startSpan(
+    spanName,
+    linkSpanContext ? { links: [{ context: linkSpanContext }] } : {},
+  );
+
+  try {
+    const results = await Promise.all(
+      options.scorers.map((scorer) =>
+        executeScorer(scorer, options.input, options.output, evalSpan),
+      ),
+    );
+
+    const hasErrors = results.some((r) => r.error);
+    if (hasErrors) {
+      evalSpan.setStatus({
+        code: SpanStatusCode.ERROR,
+        message: 'One or more scorers failed',
+      });
+    } else {
+      evalSpan.setStatus({ code: SpanStatusCode.OK });
+    }
+
+    return results;
+  } catch (err) {
+    const error = err instanceof Error ? err : new Error(String(err));
+    evalSpan.recordException(error);
+    evalSpan.setStatus({
+      code: SpanStatusCode.ERROR,
+      message: error.message,
+    });
+    return [];
+  } finally {
+    evalSpan.end();
+  }
+}

--- a/packages/ai/src/online-evals/types.ts
+++ b/packages/ai/src/online-evals/types.ts
@@ -1,0 +1,20 @@
+import type { Score } from '../evals/scorers';
+
+/**
+ * Sampling configuration for online evaluation.
+ */
+export type EvalSampling = {
+  /** Sample rate between 0.0 and 1.0 (default: 1.0 = 100%) */
+  rate: number;
+};
+
+/**
+ * Result of executing an online scorer.
+ */
+export type ScorerResult = {
+  name: string;
+  score: Score;
+  error?: string;
+};
+
+export type { Score };

--- a/packages/ai/src/otel/withSpan.ts
+++ b/packages/ai/src/otel/withSpan.ts
@@ -93,17 +93,25 @@ type WithSpanMeta = {
  * res.end();
  * ```
  */
+/**
+ * Options for withSpan configuration.
+ */
+export type WithSpanOptions = {
+  /** Custom OpenTelemetry tracer instance */
+  tracer?: Tracer;
+  /** Timeout for abandoned streams (default: 600,000ms / 10 minutes) */
+  timeoutMs?: number;
+  /** Redaction policy to override global policy for this span */
+  redactionPolicy?: AxiomAIRedactionPolicy;
+};
+
 export function withSpan<Return, Capability extends string = string, Step extends string = string>(
   meta: WithSpanMeta & {
     capability: ValidateName<Capability>;
     step: ValidateName<Step>;
   },
   fn: (span: Span) => Promise<Return>,
-  opts?: {
-    tracer?: Tracer;
-    timeoutMs?: number;
-    redactionPolicy?: AxiomAIRedactionPolicy;
-  },
+  opts?: WithSpanOptions,
 ): Promise<Return> {
   const tracer = opts?.tracer ?? getTracer();
 

--- a/packages/ai/test/online-evals/executor.test.ts
+++ b/packages/ai/test/online-evals/executor.test.ts
@@ -1,0 +1,393 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { SpanStatusCode } from '@opentelemetry/api';
+import { onlineEval } from '../../src/online-evals';
+import type { ScorerLike } from '../../src/evals/scorers';
+
+function createTestScorer<TInput = unknown, TOutput = unknown>(
+  name: string,
+  fn: (args: {
+    input?: TInput;
+    output: TOutput;
+  }) =>
+    | { score: number | null; metadata?: Record<string, unknown> }
+    | Promise<{ score: number | null; metadata?: Record<string, unknown> }>,
+): ScorerLike<TInput, unknown, TOutput> {
+  const scorer = fn as ScorerLike<TInput, unknown, TOutput>;
+  Object.defineProperty(scorer, 'name', {
+    value: name,
+    configurable: true,
+    enumerable: true,
+  });
+  return scorer;
+}
+
+const mockSpanContext = {
+  traceId: 'test-trace-id-00000000000000000',
+  spanId: 'parent-span-id-0',
+  traceFlags: 1,
+};
+
+const mockScorerSpan = {
+  setAttributes: vi.fn(),
+  setStatus: vi.fn(),
+  recordException: vi.fn(),
+  end: vi.fn(),
+  spanContext: vi.fn(() => ({ traceId: 'test-trace-id', spanId: 'scorer-span-id', traceFlags: 1 })),
+};
+
+const mockEvalSpan = {
+  setAttributes: vi.fn(),
+  setStatus: vi.fn(),
+  recordException: vi.fn(),
+  end: vi.fn(),
+  spanContext: vi.fn(() => ({ traceId: 'test-trace-id', spanId: 'eval-span-id', traceFlags: 1 })),
+};
+
+const mockParentSpan = {
+  setAttributes: vi.fn(),
+  setStatus: vi.fn(),
+  recordException: vi.fn(),
+  end: vi.fn(),
+  spanContext: vi.fn(() => mockSpanContext),
+};
+
+const mockTracer = {
+  startSpan: vi.fn((_name: string) => mockScorerSpan),
+};
+
+let startSpanCallCount = 0;
+
+vi.mock('@opentelemetry/api', async () => {
+  const actual = await vi.importActual('@opentelemetry/api');
+  return {
+    ...actual,
+    trace: {
+      getTracer: vi.fn(() => mockTracer),
+      setSpan: vi.fn((ctx) => ctx),
+      getSpan: vi.fn(() => mockParentSpan),
+    },
+    context: {
+      active: vi.fn(() => ({})),
+      with: vi.fn((_ctx, fn) => fn()),
+    },
+  };
+});
+
+describe('onlineEval', () => {
+  const baseInput = 'test input';
+  const baseOutput = 'test output';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    startSpanCallCount = 0;
+    mockTracer.startSpan.mockImplementation((name: string) => {
+      startSpanCallCount++;
+      if (name.match(/^eval \w+\/\w+$/) || name.match(/^eval \w+$/)) {
+        return startSpanCallCount === 1 ? mockEvalSpan : mockScorerSpan;
+      }
+      return mockScorerSpan;
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('basic execution', () => {
+    it('does nothing when scorers array is empty', async () => {
+      const results = await onlineEval({ capability: 'qa' }, { output: baseOutput, scorers: [] });
+
+      expect(results).toEqual([]);
+      expect(mockTracer.startSpan).not.toHaveBeenCalled();
+    });
+
+    it('executes a single scorer', async () => {
+      const scorer = createTestScorer('test-scorer', async ({ output }) => ({
+        score: output === 'test output' ? 1 : 0,
+      }));
+
+      await onlineEval(
+        { capability: 'qa', step: 'answer' },
+        { input: baseInput, output: baseOutput, scorers: [scorer] },
+      );
+
+      expect(mockTracer.startSpan).toHaveBeenCalled();
+      expect(mockScorerSpan.end).toHaveBeenCalled();
+    });
+
+    it('executes multiple scorers in parallel', async () => {
+      const scorer1 = createTestScorer('scorer-1', async () => ({ score: 0.8 }));
+      const scorer2 = createTestScorer('scorer-2', async () => ({ score: 0.6 }));
+
+      await onlineEval({ capability: 'qa' }, { output: baseOutput, scorers: [scorer1, scorer2] });
+
+      // eval span + 2 scorer spans
+      expect(mockTracer.startSpan).toHaveBeenCalledTimes(3);
+    });
+
+    it('handles scorer errors gracefully', async () => {
+      const failingScorer = createTestScorer('failing-scorer', async () => {
+        throw new Error('Scorer failed');
+      });
+
+      const results = await onlineEval(
+        { capability: 'qa' },
+        { output: baseOutput, scorers: [failingScorer] },
+      );
+
+      expect(results).toHaveLength(1);
+      expect(results[0].error).toBe('Scorer failed');
+      expect(mockScorerSpan.recordException).toHaveBeenCalled();
+      expect(mockScorerSpan.setStatus).toHaveBeenCalledWith(
+        expect.objectContaining({ code: SpanStatusCode.ERROR }),
+      );
+    });
+
+    it('passes input and output to scorer', async () => {
+      const receivedArgs: { input?: unknown; output?: unknown }[] = [];
+
+      const scorer = createTestScorer('args-checker', async (args) => {
+        receivedArgs.push(args);
+        return { score: 1 };
+      });
+
+      const customInput = { query: 'hello' };
+      const customOutput = { response: 'world' };
+
+      await onlineEval(
+        { capability: 'qa' },
+        { input: customInput, output: customOutput, scorers: [scorer] },
+      );
+
+      expect(receivedArgs).toHaveLength(1);
+      expect(receivedArgs[0].input).toEqual({ query: 'hello' });
+      expect(receivedArgs[0].output).toEqual({ response: 'world' });
+    });
+  });
+
+  describe('return value', () => {
+    it('returns scorer results', async () => {
+      const scorer = createTestScorer('test', async () => ({ score: 0.75 }));
+
+      const results = await onlineEval(
+        { capability: 'qa' },
+        { output: baseOutput, scorers: [scorer] },
+      );
+
+      expect(results).toHaveLength(1);
+      expect(results[0].name).toBe('test');
+      expect(results[0].score).toEqual({ score: 0.75 });
+    });
+
+    it('returns empty array when no scorers', async () => {
+      const results = await onlineEval({ capability: 'qa' }, { output: baseOutput, scorers: [] });
+      expect(results).toEqual([]);
+    });
+
+    it('returns empty array when sampling rejects', async () => {
+      const scorer = createTestScorer('test', async () => ({ score: 1 }));
+
+      const results = await onlineEval(
+        { capability: 'qa' },
+        { output: baseOutput, scorers: [scorer], sampling: { rate: 0 } },
+      );
+
+      expect(results).toEqual([]);
+    });
+  });
+
+  describe('sampling', () => {
+    it('always runs when sampling is not configured', async () => {
+      let executed = false;
+      const scorer = createTestScorer('test', async () => {
+        executed = true;
+        return { score: 1 };
+      });
+
+      await onlineEval({ capability: 'qa' }, { output: baseOutput, scorers: [scorer] });
+      expect(executed).toBe(true);
+    });
+
+    it('always runs when sampling rate is 1.0', async () => {
+      let executed = false;
+      const scorer = createTestScorer('test', async () => {
+        executed = true;
+        return { score: 1 };
+      });
+
+      await onlineEval(
+        { capability: 'qa' },
+        { output: baseOutput, scorers: [scorer], sampling: { rate: 1.0 } },
+      );
+      expect(executed).toBe(true);
+    });
+
+    it('never runs when sampling rate is 0', async () => {
+      let executed = false;
+      const scorer = createTestScorer('test', async () => {
+        executed = true;
+        return { score: 1 };
+      });
+
+      await onlineEval(
+        { capability: 'qa' },
+        { output: baseOutput, scorers: [scorer], sampling: { rate: 0 } },
+      );
+      expect(executed).toBe(false);
+    });
+
+    it('respects sampling rate probabilistically', async () => {
+      let ranCount = 0;
+      const iterations = 100;
+
+      for (let i = 0; i < iterations; i++) {
+        let executed = false;
+        const scorer = createTestScorer('test', async () => {
+          executed = true;
+          return { score: 1 };
+        });
+
+        await onlineEval(
+          { capability: 'qa' },
+          { output: baseOutput, scorers: [scorer], sampling: { rate: 0.5 } },
+        );
+        if (executed) ranCount++;
+      }
+
+      expect(ranCount).toBeGreaterThan(20);
+      expect(ranCount).toBeLessThan(80);
+    });
+  });
+
+  describe('fire-and-forget behavior', () => {
+    it('can be used with void for fire-and-forget', () => {
+      const scorer = createTestScorer('async-scorer', async () => {
+        return { score: 1 };
+      });
+
+      // void usage should not cause type errors or throw
+      expect(() => {
+        void onlineEval({ capability: 'qa' }, { output: baseOutput, scorers: [scorer] });
+      }).not.toThrow();
+    });
+
+    it('does not throw on errors', async () => {
+      const failingScorer = createTestScorer('failing-async', async () => {
+        throw new Error('Async failure');
+      });
+
+      // Should resolve without throwing
+      const results = await onlineEval(
+        { capability: 'qa' },
+        { output: baseOutput, scorers: [failingScorer] },
+      );
+
+      expect(results).toHaveLength(1);
+      expect(results[0].error).toBeDefined();
+    });
+  });
+
+  describe('span naming', () => {
+    it('creates span with capability and step', async () => {
+      const scorer = createTestScorer('test', async () => ({ score: 1 }));
+
+      await onlineEval(
+        { capability: 'qa', step: 'answer' },
+        { output: baseOutput, scorers: [scorer] },
+      );
+
+      expect(mockTracer.startSpan).toHaveBeenCalledWith('eval qa/answer', expect.anything());
+    });
+
+    it('creates span with capability only when step is omitted', async () => {
+      const scorer = createTestScorer('test', async () => ({ score: 1 }));
+
+      await onlineEval({ capability: 'summarization' }, { output: baseOutput, scorers: [scorer] });
+
+      expect(mockTracer.startSpan).toHaveBeenCalledWith('eval summarization', expect.anything());
+    });
+  });
+
+  describe('span links', () => {
+    it('creates eval span with link to active span', async () => {
+      const scorer = createTestScorer('test', async () => ({ score: 1 }));
+
+      await onlineEval({ capability: 'qa' }, { output: baseOutput, scorers: [scorer] });
+
+      expect(mockTracer.startSpan).toHaveBeenCalledWith('eval qa', {
+        links: [{ context: mockSpanContext }],
+      });
+    });
+
+    it('creates eval span with explicit link', async () => {
+      const { trace } = await import('@opentelemetry/api');
+      const explicitSpanContext = {
+        traceId: 'explicit-trace-id-0000000000000',
+        spanId: 'explicit-span-0',
+        traceFlags: 1,
+      };
+      const scorer = createTestScorer('test', async () => ({ score: 1 }));
+
+      await onlineEval(
+        { capability: 'qa', link: explicitSpanContext },
+        { output: baseOutput, scorers: [scorer] },
+      );
+
+      // Explicit link takes priority — trace.getSpan should not be called
+      expect(trace.getSpan).not.toHaveBeenCalled();
+      expect(mockTracer.startSpan).toHaveBeenCalledWith('eval qa', {
+        links: [{ context: explicitSpanContext }],
+      });
+    });
+
+    it('creates eval span without link when no active span', async () => {
+      const { trace } = await import('@opentelemetry/api');
+      vi.mocked(trace.getSpan).mockReturnValueOnce(undefined);
+      const scorer = createTestScorer('test', async () => ({ score: 1 }));
+
+      await onlineEval({ capability: 'qa' }, { output: baseOutput, scorers: [scorer] });
+
+      expect(mockTracer.startSpan).toHaveBeenCalledWith('eval qa', {});
+    });
+  });
+
+  describe('scorer metadata', () => {
+    it('sets span attributes on successful execution', async () => {
+      const scorer = createTestScorer('meta-scorer', async () => ({ score: 0.5 }));
+
+      await onlineEval({ capability: 'qa' }, { output: baseOutput, scorers: [scorer] });
+
+      expect(mockScorerSpan.setAttributes).toHaveBeenCalled();
+      expect(mockScorerSpan.setStatus).toHaveBeenCalledWith({ code: SpanStatusCode.OK });
+      expect(mockScorerSpan.end).toHaveBeenCalled();
+    });
+
+    it('records exception on scorer failure', async () => {
+      const error = new Error('Test error');
+      const scorer = createTestScorer('error-scorer', async () => {
+        throw error;
+      });
+
+      await onlineEval({ capability: 'qa' }, { output: baseOutput, scorers: [scorer] });
+
+      expect(mockScorerSpan.recordException).toHaveBeenCalledWith(error);
+      expect(mockScorerSpan.setStatus).toHaveBeenCalledWith({
+        code: SpanStatusCode.ERROR,
+        message: 'Test error',
+      });
+    });
+  });
+
+  describe('scorer without name', () => {
+    it('uses function name as default', async () => {
+      const scorer: ScorerLike = async () => ({ score: 1 });
+
+      await onlineEval({ capability: 'qa' }, { output: baseOutput, scorers: [scorer] });
+
+      expect(mockTracer.startSpan).toHaveBeenCalledWith(
+        expect.stringContaining('eval'),
+        expect.anything(),
+      );
+    });
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,6 +128,107 @@ importers:
         specifier: ^5
         version: 5.9.2
 
+  examples/online-evals-comprehensive:
+    dependencies:
+      '@ai-sdk/openai':
+        specifier: ^2.0.72
+        version: 2.0.89(zod@4.1.5)
+      '@opentelemetry/api':
+        specifier: ^1.9.0
+        version: 1.9.0
+      '@opentelemetry/exporter-trace-otlp-http':
+        specifier: ^0.202.0
+        version: 0.202.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources':
+        specifier: ^2.0.1
+        version: 2.2.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base':
+        specifier: ^2.0.1
+        version: 2.2.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-node':
+        specifier: ^2.0.1
+        version: 2.2.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions':
+        specifier: ^1.38.0
+        version: 1.38.0
+      ai:
+        specifier: ^5.0.102
+        version: 5.0.102(zod@4.1.5)
+      axiom:
+        specifier: workspace:*
+        version: link:../../packages/ai
+      dotenv:
+        specifier: ^17.2.0
+        version: 17.2.3
+      zod:
+        specifier: 'catalog:'
+        version: 4.1.5
+    devDependencies:
+      '@repo/eslint-config':
+        specifier: workspace:*
+        version: link:../../internal/eslint-config
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.17.2
+      eslint:
+        specifier: 'catalog:'
+        version: 9.33.0(jiti@2.6.1)
+      tsx:
+        specifier: ^4.20.4
+        version: 4.20.4
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.2
+
+  examples/online-evals-minimal:
+    dependencies:
+      '@ai-sdk/openai':
+        specifier: ^2.0.72
+        version: 2.0.89(zod@4.1.5)
+      '@opentelemetry/api':
+        specifier: ^1.9.0
+        version: 1.9.0
+      '@opentelemetry/exporter-trace-otlp-http':
+        specifier: ^0.202.0
+        version: 0.202.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources':
+        specifier: ^2.0.1
+        version: 2.2.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base':
+        specifier: ^2.0.1
+        version: 2.2.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-node':
+        specifier: ^2.0.1
+        version: 2.2.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions':
+        specifier: ^1.38.0
+        version: 1.38.0
+      ai:
+        specifier: ^5.0.102
+        version: 5.0.102(zod@4.1.5)
+      axiom:
+        specifier: workspace:*
+        version: link:../../packages/ai
+      dotenv:
+        specifier: ^17.2.0
+        version: 17.2.3
+    devDependencies:
+      '@repo/eslint-config':
+        specifier: workspace:*
+        version: link:../../internal/eslint-config
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.17.2
+      eslint:
+        specifier: 'catalog:'
+        version: 9.33.0(jiti@2.6.1)
+      tsx:
+        specifier: ^4.20.4
+        version: 4.20.4
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.2
+
   examples/telemetry-express:
     dependencies:
       '@ai-sdk/openai':
@@ -287,7 +388,7 @@ importers:
         version: link:../../packages/ai
       next:
         specifier: latest
-        version: 16.1.4(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 16.1.6(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -354,7 +455,7 @@ importers:
         version: link:../../packages/ai
       next:
         specifier: latest
-        version: 16.1.4(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 16.1.6(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react:
         specifier: ^19.2.0
         version: 19.2.0
@@ -421,7 +522,7 @@ importers:
         version: link:../../packages/ai
       next:
         specifier: latest
-        version: 16.1.4(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 16.1.6(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react:
         specifier: ^19.2.0
         version: 19.2.0
@@ -1382,8 +1483,8 @@ packages:
   '@next/env@16.0.7':
     resolution: {integrity: sha512-gpaNgUh5nftFKRkRQGnVi5dpcYSKGcZZkQffZ172OrG/XkrnS7UBTQ648YY+8ME92cC4IojpI2LqTC8sTDhAaw==}
 
-  '@next/env@16.1.4':
-    resolution: {integrity: sha512-gkrXnZyxPUy0Gg6SrPQPccbNVLSP3vmW8LU5dwEttEEC1RwDivk8w4O+sZIjFvPrSICXyhQDCG+y3VmjlJf+9A==}
+  '@next/env@16.1.6':
+    resolution: {integrity: sha512-N1ySLuZjnAtN3kFnwhAwPvZah8RJxKasD7x1f8shFqhncnWZn4JMfg37diLNuoHsLAlrDfM3g4mawVdtAG8XLQ==}
 
   '@next/eslint-plugin-next@16.0.4':
     resolution: {integrity: sha512-0emoVyL4Z5NEkRNb63ko/BqLC9OFULcY7mJ3lSerBCqgh/UFcjnvodyikV2bTl7XygwcamJxJAfxCo1oAVfH6g==}
@@ -1394,8 +1495,8 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-arm64@16.1.4':
-    resolution: {integrity: sha512-T8atLKuvk13XQUdVLCv1ZzMPgLPW0+DWWbHSQXs0/3TjPrKNxTmUIhOEaoEyl3Z82k8h/gEtqyuoZGv6+Ugawg==}
+  '@next/swc-darwin-arm64@16.1.6':
+    resolution: {integrity: sha512-wTzYulosJr/6nFnqGW7FrG3jfUUlEf8UjGA0/pyypJl42ExdVgC6xJgcXQ+V8QFn6niSG2Pb8+MIG1mZr2vczw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
@@ -1406,8 +1507,8 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@16.1.4':
-    resolution: {integrity: sha512-AKC/qVjUGUQDSPI6gESTx0xOnOPQ5gttogNS3o6bA83yiaSZJek0Am5yXy82F1KcZCx3DdOwdGPZpQCluonuxg==}
+  '@next/swc-darwin-x64@16.1.6':
+    resolution: {integrity: sha512-BLFPYPDO+MNJsiDWbeVzqvYd4NyuRrEYVB5k2N3JfWncuHAy2IVwMAOlVQDFjj+krkWzhY2apvmekMkfQR0CUQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
@@ -1419,8 +1520,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@next/swc-linux-arm64-gnu@16.1.4':
-    resolution: {integrity: sha512-POQ65+pnYOkZNdngWfMEt7r53bzWiKkVNbjpmCt1Zb3V6lxJNXSsjwRuTQ8P/kguxDC8LRkqaL3vvsFrce4dMQ==}
+  '@next/swc-linux-arm64-gnu@16.1.6':
+    resolution: {integrity: sha512-OJYkCd5pj/QloBvoEcJ2XiMnlJkRv9idWA/j0ugSuA34gMT6f5b7vOiCQHVRpvStoZUknhl6/UxOXL4OwtdaBw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -1433,8 +1534,8 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@next/swc-linux-arm64-musl@16.1.4':
-    resolution: {integrity: sha512-3Wm0zGYVCs6qDFAiSSDL+Z+r46EdtCv/2l+UlIdMbAq9hPJBvGu/rZOeuvCaIUjbArkmXac8HnTyQPJFzFWA0Q==}
+  '@next/swc-linux-arm64-musl@16.1.6':
+    resolution: {integrity: sha512-S4J2v+8tT3NIO9u2q+S0G5KdvNDjXfAv06OhfOzNDaBn5rw84DGXWndOEB7d5/x852A20sW1M56vhC/tRVbccQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -1447,8 +1548,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@next/swc-linux-x64-gnu@16.1.4':
-    resolution: {integrity: sha512-lWAYAezFinaJiD5Gv8HDidtsZdT3CDaCeqoPoJjeB57OqzvMajpIhlZFce5sCAH6VuX4mdkxCRqecCJFwfm2nQ==}
+  '@next/swc-linux-x64-gnu@16.1.6':
+    resolution: {integrity: sha512-2eEBDkFlMMNQnkTyPBhQOAyn2qMxyG2eE7GPH2WIDGEpEILcBPI/jdSv4t6xupSP+ot/jkfrCShLAa7+ZUPcJQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -1461,8 +1562,8 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@next/swc-linux-x64-musl@16.1.4':
-    resolution: {integrity: sha512-fHaIpT7x4gA6VQbdEpYUXRGyge/YbRrkG6DXM60XiBqDM2g2NcrsQaIuj375egnGFkJow4RHacgBOEsHfGbiUw==}
+  '@next/swc-linux-x64-musl@16.1.6':
+    resolution: {integrity: sha512-oicJwRlyOoZXVlxmIMaTq7f8pN9QNbdes0q2FXfRsPhfCi8n8JmOZJm5oo1pwDaFbnnD421rVU409M3evFbIqg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -1474,8 +1575,8 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-arm64-msvc@16.1.4':
-    resolution: {integrity: sha512-MCrXxrTSE7jPN1NyXJr39E+aNFBrQZtO154LoCz7n99FuKqJDekgxipoodLNWdQP7/DZ5tKMc/efybx1l159hw==}
+  '@next/swc-win32-arm64-msvc@16.1.6':
+    resolution: {integrity: sha512-gQmm8izDTPgs+DCWH22kcDmuUp7NyiJgEl18bcr8irXA5N2m2O+JQIr6f3ct42GOs9c0h8QF3L5SzIxcYAAXXw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
@@ -1486,8 +1587,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@16.1.4':
-    resolution: {integrity: sha512-JSVlm9MDhmTXw/sO2PE/MRj+G6XOSMZB+BcZ0a7d6KwVFZVpkHcb2okyoYFBaco6LeiL53BBklRlOrDDbOeE5w==}
+  '@next/swc-win32-x64-msvc@16.1.6':
+    resolution: {integrity: sha512-NRfO39AIrzBnixKbjuo2YiYhB6o9d8v/ymU9m/Xk8cyVk+k7XylniXkHwjs4s70wedVffc6bQNbufk5v0xEm0A==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -3627,6 +3728,7 @@ packages:
 
   glob@10.4.5:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   globals@14.0.0:
@@ -4246,8 +4348,8 @@ packages:
       sass:
         optional: true
 
-  next@16.1.4:
-    resolution: {integrity: sha512-gKSecROqisnV7Buen5BfjmXAm7Xlpx9o2ueVQRo5DxQcjC8d330dOM1xiGWc2k3Dcnz0In3VybyRPOsudwgiqQ==}
+  next@16.1.6:
+    resolution: {integrity: sha512-hkyRkcu5x/41KoqnROkfTm2pZVbKxvbZRuNvKXLRXxs3VfyO0WhY50TQS40EuKO9SW3rBj/sF3WbVwDACeMZyw==}
     engines: {node: '>=20.9.0'}
     hasBin: true
     peerDependencies:
@@ -6052,7 +6154,7 @@ snapshots:
 
   '@next/env@16.0.7': {}
 
-  '@next/env@16.1.4': {}
+  '@next/env@16.1.6': {}
 
   '@next/eslint-plugin-next@16.0.4':
     dependencies:
@@ -6061,49 +6163,49 @@ snapshots:
   '@next/swc-darwin-arm64@16.0.7':
     optional: true
 
-  '@next/swc-darwin-arm64@16.1.4':
+  '@next/swc-darwin-arm64@16.1.6':
     optional: true
 
   '@next/swc-darwin-x64@16.0.7':
     optional: true
 
-  '@next/swc-darwin-x64@16.1.4':
+  '@next/swc-darwin-x64@16.1.6':
     optional: true
 
   '@next/swc-linux-arm64-gnu@16.0.7':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@16.1.4':
+  '@next/swc-linux-arm64-gnu@16.1.6':
     optional: true
 
   '@next/swc-linux-arm64-musl@16.0.7':
     optional: true
 
-  '@next/swc-linux-arm64-musl@16.1.4':
+  '@next/swc-linux-arm64-musl@16.1.6':
     optional: true
 
   '@next/swc-linux-x64-gnu@16.0.7':
     optional: true
 
-  '@next/swc-linux-x64-gnu@16.1.4':
+  '@next/swc-linux-x64-gnu@16.1.6':
     optional: true
 
   '@next/swc-linux-x64-musl@16.0.7':
     optional: true
 
-  '@next/swc-linux-x64-musl@16.1.4':
+  '@next/swc-linux-x64-musl@16.1.6':
     optional: true
 
   '@next/swc-win32-arm64-msvc@16.0.7':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@16.1.4':
+  '@next/swc-win32-arm64-msvc@16.1.6':
     optional: true
 
   '@next/swc-win32-x64-msvc@16.0.7':
     optional: true
 
-  '@next/swc-win32-x64-msvc@16.1.4':
+  '@next/swc-win32-x64-msvc@16.1.6':
     optional: true
 
   '@nodelib/fs.scandir@2.1.5':
@@ -6372,7 +6474,7 @@ snapshots:
   '@opentelemetry/instrumentation-amqplib@0.49.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.1.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation': 0.202.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.38.0
     transitivePeerDependencies:
@@ -6390,7 +6492,7 @@ snapshots:
   '@opentelemetry/instrumentation-aws-sdk@0.54.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.1.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation': 0.202.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/propagation-utils': 0.31.3(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.38.0
@@ -6417,7 +6519,7 @@ snapshots:
   '@opentelemetry/instrumentation-connect@0.46.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.1.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation': 0.202.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.38.0
       '@types/connect': 3.4.38
@@ -6449,7 +6551,7 @@ snapshots:
   '@opentelemetry/instrumentation-express@0.51.1(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.1.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation': 0.202.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.38.0
     transitivePeerDependencies:
@@ -6467,7 +6569,7 @@ snapshots:
   '@opentelemetry/instrumentation-fastify@0.47.1(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.1.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation': 0.202.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.38.0
     transitivePeerDependencies:
@@ -6476,7 +6578,7 @@ snapshots:
   '@opentelemetry/instrumentation-fs@0.22.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.1.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation': 0.202.0(@opentelemetry/api@1.9.0)
     transitivePeerDependencies:
       - supports-color
@@ -6506,7 +6608,7 @@ snapshots:
   '@opentelemetry/instrumentation-hapi@0.49.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.1.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation': 0.202.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.38.0
     transitivePeerDependencies:
@@ -6560,7 +6662,7 @@ snapshots:
   '@opentelemetry/instrumentation-koa@0.50.2(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.1.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation': 0.202.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.38.0
     transitivePeerDependencies:
@@ -6593,7 +6695,7 @@ snapshots:
   '@opentelemetry/instrumentation-mongoose@0.49.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.1.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation': 0.202.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.38.0
     transitivePeerDependencies:
@@ -6645,7 +6747,7 @@ snapshots:
   '@opentelemetry/instrumentation-pg@0.54.1(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.1.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation': 0.202.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.38.0
       '@opentelemetry/sql-common': 0.41.0(@opentelemetry/api@1.9.0)
@@ -6658,7 +6760,7 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/api-logs': 0.202.0
-      '@opentelemetry/core': 2.1.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation': 0.202.0(@opentelemetry/api@1.9.0)
     transitivePeerDependencies:
       - supports-color
@@ -6684,7 +6786,7 @@ snapshots:
   '@opentelemetry/instrumentation-restify@0.48.2(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.1.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation': 0.202.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.38.0
     transitivePeerDependencies:
@@ -6725,7 +6827,7 @@ snapshots:
   '@opentelemetry/instrumentation-undici@0.13.2(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.1.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation': 0.202.0(@opentelemetry/api@1.9.0)
     transitivePeerDependencies:
       - supports-color
@@ -6851,35 +6953,35 @@ snapshots:
   '@opentelemetry/resource-detector-alibaba-cloud@0.31.3(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.1.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.38.0
 
   '@opentelemetry/resource-detector-aws@2.3.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.1.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.38.0
 
   '@opentelemetry/resource-detector-azure@0.9.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.1.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.38.0
 
   '@opentelemetry/resource-detector-container@0.7.3(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.1.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.38.0
 
   '@opentelemetry/resource-detector-gcp@0.36.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.1.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.38.0
       gcp-metadata: 6.1.1
@@ -7042,7 +7144,7 @@ snapshots:
   '@opentelemetry/sql-common@0.41.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.1.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -8265,7 +8367,7 @@ snapshots:
       '@next/eslint-plugin-next': 16.0.4
       eslint: 9.33.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.33.0(jiti@2.6.1))(typescript@5.9.2))(eslint@9.33.0(jiti@2.6.1)))(eslint@9.33.0(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.33.0(jiti@2.6.1))
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.33.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.33.0(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.33.0(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.33.0(jiti@2.6.1))
@@ -8292,7 +8394,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.33.0(jiti@2.6.1))(typescript@5.9.2))(eslint@9.33.0(jiti@2.6.1)))(eslint@9.33.0(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.33.0(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -8307,14 +8409,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.48.0(eslint@9.33.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.33.0(jiti@2.6.1))(typescript@5.9.2))(eslint@9.33.0(jiti@2.6.1)))(eslint@9.33.0(jiti@2.6.1)))(eslint@9.33.0(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.48.0(eslint@9.33.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.33.0(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.48.0(eslint@9.33.0(jiti@2.6.1))(typescript@5.9.2)
       eslint: 9.33.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.33.0(jiti@2.6.1))(typescript@5.9.2))(eslint@9.33.0(jiti@2.6.1)))(eslint@9.33.0(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.33.0(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -8329,7 +8431,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.33.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.48.0(eslint@9.33.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.33.0(jiti@2.6.1))(typescript@5.9.2))(eslint@9.33.0(jiti@2.6.1)))(eslint@9.33.0(jiti@2.6.1)))(eslint@9.33.0(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.48.0(eslint@9.33.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.33.0(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -9273,9 +9375,9 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  next@16.1.4(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  next@16.1.6(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      '@next/env': 16.1.4
+      '@next/env': 16.1.6
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.8.31
       caniuse-lite: 1.0.30001735
@@ -9284,23 +9386,23 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       styled-jsx: 5.1.6(react@18.3.1)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 16.1.4
-      '@next/swc-darwin-x64': 16.1.4
-      '@next/swc-linux-arm64-gnu': 16.1.4
-      '@next/swc-linux-arm64-musl': 16.1.4
-      '@next/swc-linux-x64-gnu': 16.1.4
-      '@next/swc-linux-x64-musl': 16.1.4
-      '@next/swc-win32-arm64-msvc': 16.1.4
-      '@next/swc-win32-x64-msvc': 16.1.4
+      '@next/swc-darwin-arm64': 16.1.6
+      '@next/swc-darwin-x64': 16.1.6
+      '@next/swc-linux-arm64-gnu': 16.1.6
+      '@next/swc-linux-arm64-musl': 16.1.6
+      '@next/swc-linux-x64-gnu': 16.1.6
+      '@next/swc-linux-x64-musl': 16.1.6
+      '@next/swc-win32-arm64-msvc': 16.1.6
+      '@next/swc-win32-x64-msvc': 16.1.6
       '@opentelemetry/api': 1.9.0
       sharp: 0.34.4
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
 
-  next@16.1.4(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+  next@16.1.6(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
     dependencies:
-      '@next/env': 16.1.4
+      '@next/env': 16.1.6
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.8.31
       caniuse-lite: 1.0.30001735
@@ -9309,14 +9411,14 @@ snapshots:
       react-dom: 19.2.0(react@19.2.0)
       styled-jsx: 5.1.6(@babel/core@7.28.5)(react@19.2.0)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 16.1.4
-      '@next/swc-darwin-x64': 16.1.4
-      '@next/swc-linux-arm64-gnu': 16.1.4
-      '@next/swc-linux-arm64-musl': 16.1.4
-      '@next/swc-linux-x64-gnu': 16.1.4
-      '@next/swc-linux-x64-musl': 16.1.4
-      '@next/swc-win32-arm64-msvc': 16.1.4
-      '@next/swc-win32-x64-msvc': 16.1.4
+      '@next/swc-darwin-arm64': 16.1.6
+      '@next/swc-darwin-x64': 16.1.6
+      '@next/swc-linux-arm64-gnu': 16.1.6
+      '@next/swc-linux-arm64-musl': 16.1.6
+      '@next/swc-linux-x64-gnu': 16.1.6
+      '@next/swc-linux-x64-musl': 16.1.6
+      '@next/swc-win32-arm64-msvc': 16.1.6
+      '@next/swc-win32-x64-msvc': 16.1.6
       '@opentelemetry/api': 1.9.0
       sharp: 0.34.4
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary

Adds online evaluations for production monitoring. Unlike offline evals (CI/CD or developer machine with expected values), online evals run on live traffic without ground truth.

## Key Features

- **Online scorers**: Evaluate output alone or in context of input — works with simple checks, heuristics, or LLM judges
- **Sampling**: Reduce overhead by evaluating a percentage of traffic
- **Async execution**: `onlineEval()` runs asynchronously and can be awaited when needed (e.g., before flushing telemetry in short-lived processes) — errors are recorded on spans but never thrown

## API

`onlineEval(meta, options)` is a standalone function called explicitly, typically inside `withSpan`:

```typescript
import { generateText, generateObject } from 'ai';
import { createOpenAI } from '@ai-sdk/openai';
import { withSpan, wrapAISDKModel, Scorer, onlineEval } from 'axiom/ai';
import { z } from 'zod';

const openai = createOpenAI({ apiKey: process.env['OPENAI_API_KEY']! });
const model = wrapAISDKModel(openai('gpt-4o'));
const judgeModel = wrapAISDKModel(openai('gpt-4o-mini'));

const formatScorer = Scorer(
  'format-check',
  ({ output }: { output: string }) =>
    /^[A-Z].*[.!?]$/.test(output.trim())
);

const relevanceScorer = Scorer(
  'relevance',
  async ({ input, output }: { input: string; output: string }) => {
    const result = await generateObject({
      model: judgeModel,
      schema: z.object({ relevant: z.boolean() }),
      system: 'Evaluate whether the response directly answers the question.',
      prompt: `Question: ${input}\nResponse: ${output}`,
    });
    return result.object.relevant;
  },
);

const result = await withSpan(
  { capability: 'qa', step: 'answer' },
  async () => {
    const response = await generateText({ model, messages });

    await onlineEval(
      { capability: 'qa', step: 'answer' },
      {
        input: userQuestion,
        output: response.text,
        scorers: [formatScorer, relevanceScorer],
        sampling: { rate: 0.1 },
      },
    );

    return response.text;
  },
);
```

Inside `withSpan`, the eval span is naturally a child via OpenTelemetry context propagation. For deferred evaluation (after `withSpan` returns), pass a `link` in the metadata to connect the eval span to the originating generation span via an OTel span link.

## Examples

Two standalone examples and a kitchen-sink integration demonstrate online evals:

- **`examples/online-evals-minimal`** — Simplest usage: one format scorer inside `withSpan`. ~50 lines.
- **`examples/online-evals-comprehensive`** — All patterns: inside `withSpan`, deferred with explicit link, standalone with manual link, awaitable for short-lived processes. Includes an LLM judge scorer with sampling.
- **`examples/kitchen-sink`** — Real-world integration: online evals added to the support-agent's `categorize-message` step at 10% sampling.

## How to run

```bash
cd examples/online-evals-minimal
cp .env-example .env
# Fill in AXIOM_TOKEN, AXIOM_DATASET, OPENAI_API_KEY
pnpm install && pnpm start
```

Check the Axiom dashboard for eval spans with `eval.score.name` attributes and span links connecting eval spans to generation spans.