### PR TITLE
feat(ai): allow boolean score in Score objects with custom metadata

### DIFF
--- a/packages/ai/src/evals/reporter.console-utils.ts
+++ b/packages/ai/src/evals/reporter.console-utils.ts
@@ -15,6 +15,12 @@ import type { Score } from './scorers';
 import { flattenObject } from '../util/dot-path';
 import type { AxiomConnectionResolvedConfig } from '../config/resolver';
 
+/** Convert score value to number (handles boolean scores from normalizeScore) */
+function scoreToNumber(score: Score['score']): number {
+  if (typeof score === 'boolean') return score ? 1 : 0;
+  return score ?? 0;
+}
+
 export type SuiteData = {
   version: string;
   name: string;
@@ -181,7 +187,7 @@ export function printTestCaseScores(
   keys.forEach((k) => {
     const scoreData = scores[k];
     const hasError = scoreData.metadata?.error;
-    const v = scoreData.score ? scoreData.score : 0;
+    const v = scoreToNumber(scoreData.score);
 
     const rawCurrent = hasError ? 'N/A' : formatPercentage(v);
     const paddedCurrent = rawCurrent.padStart(7);
@@ -465,7 +471,7 @@ export function calculateScorerAverages(suite: SuiteData): Record<string, number
         scorerTotals[scorerName] = { sum: 0, count: 0 };
       }
       if (!score.metadata?.error) {
-        scorerTotals[scorerName].sum += score.score || 0;
+        scorerTotals[scorerName].sum += scoreToNumber(score.score);
         scorerTotals[scorerName].count += 1;
       }
     }

--- a/packages/ai/src/evals/scorer.factory.ts
+++ b/packages/ai/src/evals/scorer.factory.ts
@@ -61,6 +61,16 @@ export function createScorer<
         },
       };
     }
+    // Score object with boolean score - convert and merge is_boolean into metadata
+    if (typeof res.score === 'boolean') {
+      return {
+        score: res.score ? 1 : 0,
+        metadata: {
+          ...res.metadata,
+          [Attr.Eval.Score.IsBoolean]: true,
+        },
+      };
+    }
     return res;
   };
 

--- a/packages/ai/src/evals/scorers.ts
+++ b/packages/ai/src/evals/scorers.ts
@@ -1,7 +1,7 @@
 import type { Aggregation } from './aggregations';
 
 export type Score = {
-  score: number | null;
+  score: number | boolean | null;
   metadata?: Record<string, any>;
 };
 

--- a/packages/ai/test/evals/scorer.test.ts
+++ b/packages/ai/test/evals/scorer.test.ts
@@ -58,6 +58,25 @@ describe('Scorer runtime behavior', () => {
     });
   });
 
+  it('Score object with boolean score is normalized and metadata is merged', async () => {
+    const booleanWithMeta = Scorer('BooleanMetaTest', ({ output }: { output: string }) => {
+      const passed = output === 'true';
+      return { score: passed, metadata: { reason: passed ? 'exact match' : 'mismatch' } };
+    });
+
+    const scoreTrue = await booleanWithMeta({ output: 'true' });
+    expect(scoreTrue).toEqual({
+      score: 1,
+      metadata: { reason: 'exact match', [Attr.Eval.Score.IsBoolean]: true },
+    });
+
+    const scoreFalse = await booleanWithMeta({ output: 'false' });
+    expect(scoreFalse).toEqual({
+      score: 0,
+      metadata: { reason: 'mismatch', [Attr.Eval.Score.IsBoolean]: true },
+    });
+  });
+
   it('Score object return value is passed through unchanged', async () => {
     const customScore = {
       score: 0.8,


### PR DESCRIPTION
## Summary

- Widen the `Score` type to accept `boolean` alongside `number | null`, enabling scorers to return `{ score: true, metadata: { reason: "..." } }` — a boolean result with custom metadata
- Add a `normalizeScore` branch that converts boolean scores to `1`/`0` while merging `is_boolean` into existing metadata
- Introduce `scoreToNumber` helper in the console reporter to handle the wider type safely, fixing subtle bugs where boolean `false` and numeric `0` were treated inconsistently