### PR TITLE
docs: add AGENTS.md and .cursor/BUGBOT.md

### DIFF
--- a/.cursor/BUGBOT.md
+++ b/.cursor/BUGBOT.md
@@ -1,0 +1,141 @@
+# Project Review Guidelines
+
+## Project Context
+
+Read and understand AGENTS.md files in the repo for full context. Key facts:
+
+- **Axiom AI SDK** (`axiom` on npm) — TypeScript toolkit for OpenTelemetry-based GenAI observability
+- **Multi-version support** — Vercel AI SDK v4/v5/v6 (LanguageModel API v1/v2/v3)
+- **Multiple entry points** with different runtime requirements (see "Vitest Bundling" below)
+- **Two-pass tsup build** — client modules (`feedback.ts`) build first with `clean: true, shims: false`; server modules build second with `clean: false, shims: true`
+- **`__SDK_VERSION__`** is a build-time define from `package.json` — only available in tsup output, not in tests
+
+## Review Focus Areas
+
+- Changes are consistent with existing project structure, architecture, style, conventions, and guidelines
+- TypeScript strict mode compliance — no `any` without justification, `type` keyword for type-only imports (`verbatimModuleSyntax`)
+- OpenTelemetry span lifecycle correctness (spans must be ended, errors recorded)
+- Peer dependency compatibility — imports from `@opentelemetry/api` and `zod` must stay within declared ranges (`^1.9.0` and `^3.25 || ^4.0`)
+
+## Critical Bug Patterns
+
+### 1. Vitest Bundling in Non-Eval Entry Points
+
+**Severity: Critical — causes `ERR_MODULE_NOT_FOUND` at runtime when vitest is not installed**
+
+The root cause:
+
+- `axiom/ai/evals` (`src/evals.ts`) re-exports both `Eval` and `Scorer` from the same bundle
+- `Eval` has a top-level `import { ... } from 'vitest'` in `src/evals/eval.ts`
+- `tsup` marks `vitest` as external (not bundled), so it must be resolvable at runtime
+- **Any import from `axiom/ai/evals` — even just `Scorer` — triggers the vitest import chain**
+- Consumers who don't run evals don't have vitest installed → `ERR_MODULE_NOT_FOUND` for `vitest` or `vite`
+
+The fix is strict entry point separation: vitest-free code has dedicated entry points (`axiom/ai/evals/scorers`, `axiom/ai/evals/online`). The old import paths from `axiom/ai` and `axiom/ai/evals` emit deprecation warnings at runtime and will be removed in a future version.
+
+**Detection — flag ANY of these:**
+
+- New static `import` or `require` of `vitest`, `vitest/node`, `vitest/runners`, or `vite-tsconfig-paths` in files outside `src/evals/eval.ts`, `src/evals/custom-runner.ts`, `src/evals/run-vitest.ts`, or test files
+- New re-exports from `src/evals/eval.ts` added to a non-eval entry point (`src/index.ts`, `src/evals/scorers.ts`, `src/evals/online.ts`, `src/evals/aggregations.ts`, `src/feedback.ts`)
+- Code that imports `Scorer` from `axiom/ai/evals` or `axiom/ai` instead of `axiom/ai/evals/scorers`
+- Code that imports `onlineEval` from `axiom/ai` instead of `axiom/ai/evals/online`
+- Adding vitest-dependent code to files reachable from vitest-free entry points
+
+**Correct patterns:**
+
+```typescript
+// Scorers (vitest-free):
+import { Scorer } from 'axiom/ai/evals/scorers';
+
+// Online evaluations (vitest-free):
+import { onlineEval } from 'axiom/ai/evals/online';
+
+// Offline eval framework (vitest required — only in eval/test files):
+import { Eval } from 'axiom/ai/evals';
+
+// CLI code — dynamic import only:
+const { runVitest } = await import('../../evals/run-vitest');
+```
+
+**Entry point dependency map:**
+
+| Entry Point | vitest Required | Safe Without vitest |
+|---|---|---|
+| `axiom/ai` | NO | YES |
+| `axiom/ai/evals/scorers` | NO | YES |
+| `axiom/ai/evals/online` | NO | YES |
+| `axiom/ai/evals/aggregations` | NO | YES |
+| `axiom/ai/feedback` | NO | YES (client-safe) |
+| `axiom/ai/config` | NO | YES |
+| `axiom/ai/evals` | **YES** | NO — offline eval runner only |
+
+### 2. Static Vitest Imports in CLI Code
+
+**Severity: High — breaks `npx axiom login` and other non-eval CLI commands**
+
+The CLI (`src/cli/`, `src/bin.ts`) must never statically import vitest or vitest-dependent modules. This is enforced by ESLint `no-restricted-imports` but can be bypassed.
+
+**Detection — flag ANY of these:**
+
+- Static `import` from `vitest`, `vitest/node`, `vitest/runners`, or `vite-tsconfig-paths` in `src/cli/**` or `src/bin.ts`
+- Static `import` from `**/evals/run-vitest` in CLI code (must use `await import()`)
+- New tsup entry points that bundle CLI code with vitest-dependent modules
+
+### 3. Missing specificationVersion Handling
+
+**Severity: High — silently breaks for users on unhandled AI SDK versions**
+
+The middleware auto-detects the model's `specificationVersion` (v1/v2/v3) and delegates to the correct implementation. Any new middleware code must handle all three versions.
+
+**Detection:**
+
+- New code in `src/otel/middleware.ts` that switches on `specificationVersion` but doesn't handle all cases
+- New `wrapGenerate` or `wrapStream` implementations that only cover one API version
+- Missing version checks when accessing version-specific model properties
+
+### 4. Stream Aggregator Completeness
+
+**Severity: Medium — leaves spans with incomplete attributes**
+
+`TransformStream` chunks in `src/otel/streaming/aggregators.ts` must be fully consumed. Partial reads leave OTEL spans without final token counts, finish reasons, or tool call results.
+
+**Detection:**
+
+- Changes to aggregator logic that skip chunk types or break early
+- New stream handling code that doesn't aggregate all chunk fields
+- Missing `flush()` or final aggregation step in stream wrappers
+
+### 5. Build Pass Ordering
+
+**Severity: Medium — client bundles break if server dependencies leak in**
+
+The tsup build has two passes. Client modules (`feedback.ts`) must never import server-only dependencies (`@opentelemetry/api`, `async_hooks`, Node.js builtins).
+
+**Detection:**
+
+- New imports in `src/feedback.ts` that reference Node.js APIs or OTEL
+- Moving `feedback.ts` to the server-side build pass
+- Adding new client entry points without adding them to the first (client) build pass
+
+### 6. Redaction Policy Bypass
+
+**Severity: Medium — sensitive prompt/completion content leaks to telemetry**
+
+`src/otel/utils/redaction.ts` implements content redaction for spans. All prompt and completion content must flow through the redaction policy before being set as span attributes.
+
+**Detection:**
+
+- New span attributes containing prompt/completion content that bypass `redaction.ts` utilities
+- Direct `span.setAttribute()` calls with raw user input or model output
+
+## Excluded Paths
+
+- **DO NOT** review the contents of the `.cursor/` directory
+- **DO NOT** review `node_modules/`, `dist/`, or generated files
+
+## Forbidden Review Behaviors
+
+- **DO NOT** suggest styles or conventions not used in the project
+- **DO NOT** flag formatting issues (Prettier handles this)
+- **DO NOT** suggest adding JSDoc comments to internal functions
+- **DO NOT** suggest converting working code to use different libraries

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,108 @@
+# AGENTS.md
+
+This file provides guidance to coding agents when working with code in this repository.
+
+## Project
+
+Axiom AI SDK (`axiom` on npm) — TypeScript toolkit for adding OpenTelemetry-based observability to GenAI applications. Supports Vercel AI SDK v4/v5/v6 (LanguageModel API v1/v2/v3).
+
+Published as a single package with multiple entry points:
+- `axiom/ai` — Instrumentation (middleware, withSpan, wrapTool, onlineEval)
+- `axiom/ai/evals` — Offline evaluation framework (vitest-based)
+- `axiom/ai/evals/scorers` — Vitest-free scorer entry point
+- `axiom/ai/evals/aggregations` — Score aggregation utilities
+- `axiom/ai/config` — Configuration loading (c12-based)
+- `axiom/ai/feedback` — Client-side feedback (no Node.js shims)
+
+## Commands
+
+```bash
+pnpm install              # Install dependencies
+pnpm build                # Build all packages (turbo)
+pnpm test                 # Run all tests (turbo)
+pnpm lint                 # ESLint
+pnpm typecheck            # tsc --noEmit
+pnpm format               # Prettier write
+pnpm format:check         # Prettier check
+
+# Package-level (from packages/ai/)
+pnpm test                 # vitest run
+pnpm test:watch           # vitest --watch
+
+# Single test file
+cd packages/ai && npx vitest run test/otel/middleware.test.ts
+```
+
+## Monorepo Layout
+
+```
+packages/ai/       # Main SDK package (published as "axiom")
+internal/          # Shared tooling (eslint-config)
+examples/          # Reference apps (telemetry-*, evals-*, online-evals-*)
+```
+
+pnpm workspaces + Turborepo. Node.js 20.x/22.x/24.x.
+
+## Architecture
+
+### OpenTelemetry Instrumentation (`src/otel/`)
+
+The core of the SDK. Creates OpenTelemetry spans around AI model calls.
+
+- **`middleware.ts`** — The main entry point. `axiomAIMiddleware()` auto-detects the model's `specificationVersion` (v1/v2/v3) and delegates to the correct versioned middleware. Each version implements `wrapGenerate` and `wrapStream` hooks.
+- **`initAxiomAI.ts`** — `initAxiomAI({ tracer })` stores tracer scope in `globalThis` for cross-context propagation (e.g. Next.js). Must be called once during instrumentation setup.
+- **`withSpan.ts`** — Manual span creation for wrapping arbitrary AI call sequences.
+- **`wrapTool.ts`** — Wraps Vercel AI SDK `tool()` definitions with span instrumentation.
+- **`streaming/aggregators.ts`** — Stream chunk aggregators (text, tool calls, stats) per API version. Used by `wrapStream` to collect attributes from `TransformStream` chunks.
+- **`semconv/attributes.ts`** — Centralized `Attr` object mapping all span attribute keys (GenAI semantic conventions + Axiom custom attributes).
+- **`utils/wrapperUtils.ts`** — Shared span lifecycle helpers (`withSpanHandling`, `createStreamChildSpan`, `setBaseAttributes`, etc.).
+- **`utils/redaction.ts`** — Redaction policy support for controlling what content is captured in spans.
+
+### Multi-Version Support
+
+The SDK maintains parallel implementations for Vercel AI SDK API versions:
+- `AxiomWrappedLanguageModelV1.ts` / V2 / V3 — Legacy wrapper classes
+- `middleware.ts` — Current approach using middleware pattern (V1/V2/V3)
+- Dev dependencies use aliased packages (`aiv4`/`aiv5`/`aiv6`, `@ai-sdk/openaiv1`/v2/v3) for testing across versions
+
+### Evaluations (`src/evals/`)
+
+Offline evaluation framework built on vitest:
+- **`eval.ts`** — `Eval()` creates vitest describe blocks that run tasks against collections, score results, and report
+- **`custom-runner.ts`** — Custom vitest runner for eval-specific lifecycle hooks
+- **`scorer.factory.ts`** — `createScorer()` / `Scorer()` factory for defining scoring functions
+- **`reporter.ts`** — Console reporter with formatted eval output
+
+### Online Evaluations (`src/online-evals/`)
+
+Production-safe scoring that runs without vitest dependency. `onlineEval()` executes scorers within the current OTEL context.
+
+### CLI (`src/cli/`, `src/bin.ts`)
+
+`axiom` binary for running evals, managing config. **Critical rule**: vitest and related imports must be dynamically imported in CLI command handlers — never at module top-level. This is enforced by eslint.
+
+### Build (`tsup.config.ts`)
+
+Two-pass build:
+1. Client-compatible modules (`feedback.ts`) — `clean: true`, `shims: false`
+2. Server-side modules (everything else) — `clean: false`, `shims: true`
+
+Both passes output ESM + CJS. `handlebars` is bundled (`noExternal`); vitest and OTEL are external.
+
+`__SDK_VERSION__` is defined at build time from `package.json`.
+
+## Testing
+
+Vitest with `globals: true` (no need to import `describe`/`it`/`expect`). Tests in `packages/ai/test/`.
+
+OTEL tests use `createOtelTestSetup()` from `test/helpers/otel-test-setup.ts` which provides an in-memory span exporter and `getSpans()` for assertions.
+
+HTTP mocking uses `msw` (Mock Service Worker).
+
+## Conventions
+
+- **Commits**: [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) with semantic PR titles (enforced by CI)
+- **Formatting**: Prettier — single quotes, semicolons, trailing commas, 100 char width, 2-space indent
+- **TypeScript**: Strict mode, `verbatimModuleSyntax`, bundler module resolution
+- **Imports**: `type` keyword required for type-only imports (enforced by `verbatimModuleSyntax`)
+- **Peer dependencies**: `@opentelemetry/api` ^1.9.0, `zod` ^3.25 || ^4.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
## Summary

- Add `AGENTS.md` with project context, architecture, commands, and conventions for coding agents. `CLAUDE.md` symlinks to it.
- Add `.cursor/BUGBOT.md` with review guidelines for Cursor BugBot, including six critical bug patterns:
  1. Vitest bundling in non-eval entry points
  2. Static vitest imports in CLI code
  3. Missing `specificationVersion` handling
  4. Stream aggregator completeness
  5. Build pass ordering
  6. Redaction policy bypass

## Context

BugBot reviews are only as good as the rules it's given. The previous BUGBOT.md was 19 lines and generic. This version encodes domain-specific knowledge — particularly the vitest bundling issue that has caused repeated incidents — into concrete, actionable detection rules.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only additions; no runtime or build changes, so risk is limited to potential confusion if guidance becomes outdated.
> 
> **Overview**
> Adds `AGENTS.md` to document agent-facing project context (entry points, commands, repo layout, architecture notes, and conventions).
> 
> Adds `.cursor/BUGBOT.md` with Cursor BugBot-specific review rules and concrete detection patterns for several recurring failure modes (notably vitest bundling/entry-point separation, CLI vitest import restrictions, multi-version `specificationVersion` coverage, streaming aggregation completeness, tsup build-pass ordering, and redaction policy enforcement). Also adds `CLAUDE.md` pointing to `AGENTS.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5db5b12154688184411f4b06bed4c9820e8d4f0e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->