### PR TITLE
feat(cli): add dataset management commands

### DIFF
--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -112,6 +112,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "@axiomhq/js": "^1.4.0",
     "@next/env": "^15.4.2",
     "@opentelemetry/auto-instrumentations-node": "^0.60.1",
     "@opentelemetry/context-async-hooks": "^2.0.1",

--- a/packages/ai/src/bin.ts
+++ b/packages/ai/src/bin.ts
@@ -2,6 +2,7 @@
 import { Command } from 'commander';
 import { loadEvalCommand } from './cli/commands/eval.command';
 import { loadAuthCommand } from './cli/commands/auth.command';
+import { loadDatasetCommand } from './cli/commands/dataset.command';
 import { extractOverrides } from './cli/utils/parse-flag-overrides';
 import { setupGlobalAuth } from './cli/auth/global-auth';
 
@@ -47,6 +48,7 @@ program.hook('preAction', async (_, actionCommand: Command) => {
 });
 
 loadAuthCommand(program);
+loadDatasetCommand(program);
 loadEvalCommand(program, overrides);
 loadVersionCommand(program);
 

--- a/packages/ai/src/cli/commands/dataset-create.command.ts
+++ b/packages/ai/src/cli/commands/dataset-create.command.ts
@@ -1,0 +1,49 @@
+import type { Command } from 'commander';
+import { createDatasetsClient } from '../utils/axiom-client';
+import { AxiomCLIError } from '../../util/errors';
+import c from 'tinyrainbow';
+
+export function loadDatasetCreateCommand(parent: Command): void {
+  parent
+    .command('create')
+    .description('Create a new dataset')
+    .argument('<name>', 'dataset name')
+    .option('-d, --description <DESCRIPTION>', 'dataset description')
+    .option('-r, --region <REGION>', 'dataset region')
+    .option('-t, --token <TOKEN>', 'axiom token')
+    .option('-u, --url <AXIOM URL>', 'axiom url')
+    .option('-o, --org-id <ORG ID>', 'axiom organization id')
+    .action(async (name: string, options) => {
+      try {
+        const client = createDatasetsClient({
+          token: options.token,
+          url: options.url,
+          orgId: options.orgId,
+        });
+
+        const dataset = await client.create({
+          name,
+          description: options.description,
+          region: options.region,
+        });
+
+        console.log(c.green(`\n✓ Dataset created successfully:\n`));
+        console.log(c.bold(`  Name: ${dataset.name}`));
+        if (dataset.description) {
+          console.log(c.dim(`  Description: ${dataset.description}`));
+        }
+        console.log(c.dim(`  ID: ${dataset.id}`));
+        console.log(c.dim(`  Created: ${dataset.created}`));
+        if (dataset.region) {
+          console.log(c.dim(`  Region: ${dataset.region}`));
+        }
+        console.log('');
+      } catch (error) {
+        if (error instanceof AxiomCLIError) {
+          console.error(`\n${c.red('✗')} ${error.message}\n`);
+          process.exit(1);
+        }
+        throw error;
+      }
+    });
+}

--- a/packages/ai/src/cli/commands/dataset-delete.command.ts
+++ b/packages/ai/src/cli/commands/dataset-delete.command.ts
@@ -1,0 +1,59 @@
+import type { Command } from 'commander';
+import { createDatasetsClient } from '../utils/axiom-client';
+import { AxiomCLIError } from '../../util/errors';
+import c from 'tinyrainbow';
+
+export function loadDatasetDeleteCommand(parent: Command): void {
+  parent
+    .command('delete')
+    .description('Delete a dataset')
+    .argument('<name>', 'dataset name or ID')
+    .option('-t, --token <TOKEN>', 'axiom token')
+    .option('-u, --url <AXIOM URL>', 'axiom url')
+    .option('-o, --org-id <ORG ID>', 'axiom organization id')
+    .option('-y, --yes', 'skip confirmation prompt', false)
+    .action(async (name: string, options) => {
+      try {
+        const client = createDatasetsClient({
+          token: options.token,
+          url: options.url,
+          orgId: options.orgId,
+        });
+
+        // Confirmation prompt (unless --yes flag is provided)
+        if (!options.yes) {
+          const readline = await import('node:readline/promises');
+          const rl = readline.createInterface({
+            input: process.stdin,
+            output: process.stdout,
+          });
+
+          const answer = await rl.question(
+            c.yellow(
+              `\n⚠ Are you sure you want to delete dataset "${name}"? This cannot be undone. (y/N): `,
+            ),
+          );
+          rl.close();
+
+          if (answer.toLowerCase() !== 'y' && answer.toLowerCase() !== 'yes') {
+            console.log(c.dim('\nDeletion cancelled.'));
+            return;
+          }
+        }
+
+        const response = await client.delete(name);
+
+        if (response.status === 204) {
+          console.log(c.green(`\n✓ Dataset "${name}" deleted successfully.\n`));
+        } else {
+          throw new AxiomCLIError(`Failed to delete dataset. Status: ${response.status}`);
+        }
+      } catch (error) {
+        if (error instanceof AxiomCLIError) {
+          console.error(`\n${c.red('✗')} ${error.message}\n`);
+          process.exit(1);
+        }
+        throw error;
+      }
+    });
+}

--- a/packages/ai/src/cli/commands/dataset-get.command.ts
+++ b/packages/ai/src/cli/commands/dataset-get.command.ts
@@ -1,0 +1,46 @@
+import type { Command } from 'commander';
+import { createDatasetsClient } from '../utils/axiom-client';
+import { AxiomCLIError } from '../../util/errors';
+import c from 'tinyrainbow';
+
+export function loadDatasetGetCommand(parent: Command): void {
+  parent
+    .command('get')
+    .description('Get dataset information')
+    .argument('<name>', 'dataset name or ID')
+    .option('-t, --token <TOKEN>', 'axiom token')
+    .option('-u, --url <AXIOM URL>', 'axiom url')
+    .option('-o, --org-id <ORG ID>', 'axiom organization id')
+    .action(async (name: string, options) => {
+      try {
+        const client = createDatasetsClient({
+          token: options.token,
+          url: options.url,
+          orgId: options.orgId,
+        });
+
+        const dataset = await client.get(name);
+
+        console.log(c.green(`\n✓ Dataset information:\n`));
+        console.log(c.bold(`  Name: ${dataset.name}`));
+        if (dataset.description) {
+          console.log(c.dim(`  Description: ${dataset.description}`));
+        }
+        console.log(c.dim(`  ID: ${dataset.id}`));
+        console.log(c.dim(`  Created: ${dataset.created}`));
+        if (dataset.who) {
+          console.log(c.dim(`  Created by: ${dataset.who}`));
+        }
+        if (dataset.region) {
+          console.log(c.dim(`  Region: ${dataset.region}`));
+        }
+        console.log('');
+      } catch (error) {
+        if (error instanceof AxiomCLIError) {
+          console.error(`\n${c.red('✗')} ${error.message}\n`);
+          process.exit(1);
+        }
+        throw error;
+      }
+    });
+}

--- a/packages/ai/src/cli/commands/dataset-list.command.ts
+++ b/packages/ai/src/cli/commands/dataset-list.command.ts
@@ -1,0 +1,51 @@
+import type { Command } from 'commander';
+import { createDatasetsClient } from '../utils/axiom-client';
+import { AxiomCLIError } from '../../util/errors';
+import c from 'tinyrainbow';
+
+export function loadDatasetListCommand(parent: Command): void {
+  parent
+    .command('list')
+    .description('List all datasets')
+    .option('-t, --token <TOKEN>', 'axiom token')
+    .option('-u, --url <AXIOM URL>', 'axiom url')
+    .option('-o, --org-id <ORG ID>', 'axiom organization id')
+    .action(async (options) => {
+      try {
+        const client = createDatasetsClient({
+          token: options.token,
+          url: options.url,
+          orgId: options.orgId,
+        });
+
+        const datasets = await client.list();
+
+        if (datasets.length === 0) {
+          console.log(c.yellow('No datasets found.'));
+          return;
+        }
+
+        console.log(
+          c.green(`\n✓ Found ${datasets.length} dataset${datasets.length > 1 ? 's' : ''}:\n`),
+        );
+
+        for (const dataset of datasets) {
+          console.log(c.bold(`  ${dataset.name}`));
+          if (dataset.description) {
+            console.log(c.dim(`    ${dataset.description}`));
+          }
+          console.log(c.dim(`    ID: ${dataset.id} | Created: ${dataset.created}`));
+          if (dataset.region) {
+            console.log(c.dim(`    Region: ${dataset.region}`));
+          }
+          console.log('');
+        }
+      } catch (error) {
+        if (error instanceof AxiomCLIError) {
+          console.error(`\n${c.red('✗')} ${error.message}\n`);
+          process.exit(1);
+        }
+        throw error;
+      }
+    });
+}

--- a/packages/ai/src/cli/commands/dataset-trim.command.ts
+++ b/packages/ai/src/cli/commands/dataset-trim.command.ts
@@ -1,0 +1,61 @@
+import type { Command } from 'commander';
+import { createDatasetsClient } from '../utils/axiom-client';
+import { AxiomCLIError } from '../../util/errors';
+import c from 'tinyrainbow';
+
+export function loadDatasetTrimCommand(parent: Command): void {
+  parent
+    .command('trim')
+    .description('Trim dataset by time duration (removes data older than specified duration)')
+    .argument('<name>', 'dataset name or ID')
+    .argument('<duration>', 'duration to keep (e.g., "30m", "24h", "7d")')
+    .option('-t, --token <TOKEN>', 'axiom token')
+    .option('-u, --url <AXIOM URL>', 'axiom url')
+    .option('-o, --org-id <ORG ID>', 'axiom organization id')
+    .option('-y, --yes', 'skip confirmation prompt', false)
+    .action(async (name: string, duration: string, options) => {
+      try {
+        const client = createDatasetsClient({
+          token: options.token,
+          url: options.url,
+          orgId: options.orgId,
+        });
+
+        // Confirmation prompt (unless --yes flag is provided)
+        if (!options.yes) {
+          const readline = await import('node:readline/promises');
+          const rl = readline.createInterface({
+            input: process.stdin,
+            output: process.stdout,
+          });
+
+          const answer = await rl.question(
+            c.yellow(
+              `\n⚠ Are you sure you want to trim dataset "${name}" to keep only the last ${duration}? This cannot be undone. (y/N): `,
+            ),
+          );
+          rl.close();
+
+          if (answer.toLowerCase() !== 'y' && answer.toLowerCase() !== 'yes') {
+            console.log(c.dim('\nTrim cancelled.'));
+            return;
+          }
+        }
+
+        const result = await client.trim(name, duration);
+
+        console.log(
+          c.green(`\n✓ Dataset "${name}" trimmed successfully to keep last ${duration}.\n`),
+        );
+        if (result) {
+          console.log(c.dim(`  Trim result: ${JSON.stringify(result)}\n`));
+        }
+      } catch (error) {
+        if (error instanceof AxiomCLIError) {
+          console.error(`\n${c.red('✗')} ${error.message}\n`);
+          process.exit(1);
+        }
+        throw error;
+      }
+    });
+}

--- a/packages/ai/src/cli/commands/dataset-update.command.ts
+++ b/packages/ai/src/cli/commands/dataset-update.command.ts
@@ -1,0 +1,43 @@
+import type { Command } from 'commander';
+import { createDatasetsClient } from '../utils/axiom-client';
+import { AxiomCLIError } from '../../util/errors';
+import c from 'tinyrainbow';
+
+export function loadDatasetUpdateCommand(parent: Command): void {
+  parent
+    .command('update')
+    .description('Update dataset description')
+    .argument('<name>', 'dataset name or ID')
+    .option('-d, --description <DESCRIPTION>', 'new dataset description', '')
+    .option('-t, --token <TOKEN>', 'axiom token')
+    .option('-u, --url <AXIOM URL>', 'axiom url')
+    .option('-o, --org-id <ORG ID>', 'axiom organization id')
+    .action(async (name: string, options) => {
+      try {
+        if (options.description === undefined) {
+          throw new AxiomCLIError('Description is required. Use --description flag.');
+        }
+
+        const client = createDatasetsClient({
+          token: options.token,
+          url: options.url,
+          orgId: options.orgId,
+        });
+
+        const dataset = await client.update(name, {
+          description: options.description,
+        });
+
+        console.log(c.green(`\n✓ Dataset updated successfully:\n`));
+        console.log(c.bold(`  Name: ${dataset.name}`));
+        console.log(c.dim(`  Description: ${dataset.description}`));
+        console.log('');
+      } catch (error) {
+        if (error instanceof AxiomCLIError) {
+          console.error(`\n${c.red('✗')} ${error.message}\n`);
+          process.exit(1);
+        }
+        throw error;
+      }
+    });
+}

--- a/packages/ai/src/cli/commands/dataset.command.ts
+++ b/packages/ai/src/cli/commands/dataset.command.ts
@@ -1,0 +1,18 @@
+import type { Command } from 'commander';
+import { loadDatasetListCommand } from './dataset-list.command';
+import { loadDatasetCreateCommand } from './dataset-create.command';
+import { loadDatasetGetCommand } from './dataset-get.command';
+import { loadDatasetUpdateCommand } from './dataset-update.command';
+import { loadDatasetDeleteCommand } from './dataset-delete.command';
+import { loadDatasetTrimCommand } from './dataset-trim.command';
+
+export function loadDatasetCommand(program: Command): void {
+  const dataset = program.command('dataset').alias('datasets').description('Manage Axiom datasets');
+
+  loadDatasetListCommand(dataset);
+  loadDatasetCreateCommand(dataset);
+  loadDatasetGetCommand(dataset);
+  loadDatasetUpdateCommand(dataset);
+  loadDatasetDeleteCommand(dataset);
+  loadDatasetTrimCommand(dataset);
+}

--- a/packages/ai/src/cli/utils/axiom-client.ts
+++ b/packages/ai/src/cli/utils/axiom-client.ts
@@ -1,0 +1,47 @@
+import { AxiomWithoutBatching, datasets, type ClientOptions } from '@axiomhq/js';
+import { getAuthContext } from '../auth/global-auth';
+import { AxiomCLIError } from '../../util/errors';
+
+/**
+ * Gets Axiom client options from CLI options or auth context
+ */
+export function getAxiomClientOptions(options?: Partial<ClientOptions>): {
+  token: string;
+  url?: string;
+  orgId?: string;
+} {
+  const authContext = getAuthContext();
+
+  const token =
+    options?.token || authContext?.token || process.env.AXIOM_TOKEN || process.env.AXIOM_API_TOKEN;
+  const url = options?.url || authContext?.url || process.env.AXIOM_URL;
+  const orgId = options?.orgId || authContext?.orgId || process.env.AXIOM_ORG_ID;
+
+  if (!token) {
+    throw new AxiomCLIError(
+      'No Axiom token found. Please run `axiom auth login` or set AXIOM_TOKEN environment variable.',
+    );
+  }
+
+  return {
+    token,
+    ...(url && { url }),
+    ...(orgId && { orgId }),
+  };
+}
+
+/**
+ * Creates an Axiom client instance
+ */
+export function createAxiomClient(options?: Partial<ClientOptions>): AxiomWithoutBatching {
+  const clientOptions = getAxiomClientOptions(options);
+  return new AxiomWithoutBatching(clientOptions);
+}
+
+/**
+ * Creates a datasets service client
+ */
+export function createDatasetsClient(options?: Partial<ClientOptions>): datasets.Service {
+  const clientOptions = getAxiomClientOptions(options);
+  return new datasets.Service(clientOptions);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -590,6 +590,9 @@ importers:
 
   packages/ai:
     dependencies:
+      '@axiomhq/js':
+        specifier: ^1.4.0
+        version: 1.4.0
       '@next/env':
         specifier: ^15.4.2
         version: 15.4.6
@@ -905,6 +908,10 @@ packages:
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@axiomhq/js@1.4.0':
+    resolution: {integrity: sha512-wC5x1ud/QJMstrjpicATkyY8+ZVWEl4WlXMtA5EZf7hkj0+b191yv4yynLxLEfr/MveXora9m6CWdJq4DsbcAg==}
+    engines: {node: '>=20'}
 
   '@babel/code-frame@7.27.1':
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
@@ -3619,6 +3626,9 @@ packages:
       picomatch:
         optional: true
 
+  fetch-retry@6.0.0:
+    resolution: {integrity: sha512-BUFj1aMubgib37I3v4q78fYo63Po7t4HUPTpQ6/QE6yK6cIQrP+W43FYToeTEyg5m2Y7eFUtijUuAv/PDlWuag==}
+
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
@@ -5657,6 +5667,10 @@ snapshots:
       zod-to-json-schema: 3.24.6(zod@4.1.5)
 
   '@alloc/quick-lru@5.2.0': {}
+
+  '@axiomhq/js@1.4.0':
+    dependencies:
+      fetch-retry: 6.0.0
 
   '@babel/code-frame@7.27.1':
     dependencies:
@@ -8367,7 +8381,7 @@ snapshots:
       '@next/eslint-plugin-next': 16.0.4
       eslint: 9.33.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.33.0(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.33.0(jiti@2.6.1))(typescript@5.9.2))(eslint@9.33.0(jiti@2.6.1)))(eslint@9.33.0(jiti@2.6.1))
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.33.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.33.0(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.33.0(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.33.0(jiti@2.6.1))
@@ -8394,7 +8408,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.33.0(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.33.0(jiti@2.6.1))(typescript@5.9.2))(eslint@9.33.0(jiti@2.6.1)))(eslint@9.33.0(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -8409,14 +8423,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.48.0(eslint@9.33.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.33.0(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.48.0(eslint@9.33.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.33.0(jiti@2.6.1))(typescript@5.9.2))(eslint@9.33.0(jiti@2.6.1)))(eslint@9.33.0(jiti@2.6.1)))(eslint@9.33.0(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.48.0(eslint@9.33.0(jiti@2.6.1))(typescript@5.9.2)
       eslint: 9.33.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.33.0(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.33.0(jiti@2.6.1))(typescript@5.9.2))(eslint@9.33.0(jiti@2.6.1)))(eslint@9.33.0(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -8431,7 +8445,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.33.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.48.0(eslint@9.33.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.33.0(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.48.0(eslint@9.33.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.33.0(jiti@2.6.1))(typescript@5.9.2))(eslint@9.33.0(jiti@2.6.1)))(eslint@9.33.0(jiti@2.6.1)))(eslint@9.33.0(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -8656,6 +8670,8 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
       picomatch: 4.0.3
+
+  fetch-retry@6.0.0: {}
 
   file-entry-cache@8.0.0:
     dependencies:


### PR DESCRIPTION
Add comprehensive dataset management functionality to the CLI using @axiomhq/js:
- Install @axiomhq/js dependency for dataset API access
- Create Axiom client utility with auth context integration
- Implement dataset subcommands: list, create, get, update, delete, trim
- Support authentication via global auth, CLI flags, or env variables
- Add confirmation prompts for destructive operations
- Support command alias: 'axiom datasets' alongside 'axiom dataset'

All commands integrate seamlessly with the existing auth system and provide colorized output with proper error handling.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new CLI commands that perform destructive remote operations (`delete`/`trim`) and introduces a new dependency/client wiring path; behavior is mostly additive but impacts how credentials are sourced and used for API calls.
> 
> **Overview**
> Adds a new `axiom dataset`/`axiom datasets` CLI command group for managing datasets, including `list`, `create`, `get`, `update`, `delete`, and `trim` subcommands with colored output and consistent `AxiomCLIError` handling.
> 
> Introduces a shared `axiom-client` utility that builds `@axiomhq/js` client options from CLI flags, the existing global auth context, or environment variables, and wires the dataset command group into the main CLI entrypoint. Dependencies are updated to include `@axiomhq/js` (and lockfile changes).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d8f78ddd2e62524e3a699d2e50290b1a1922da05. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->