### PR TITLE
chore: add example staleness rule to BUGBOT.md

### DIFF
--- a/.cursor/BUGBOT.md
+++ b/.cursor/BUGBOT.md
@@ -128,6 +128,27 @@ The tsup build has two passes. Client modules (`feedback.ts`) must never import 
 - New span attributes containing prompt/completion content that bypass `redaction.ts` utilities
 - Direct `span.setAttribute()` calls with raw user input or model output
 
+### 7. Example Staleness After SDK Changes
+
+**Severity: Medium — examples drift from SDK, confusing users and hiding breakage**
+
+PRs that change SDK source code (`packages/ai/src/`) should update or at minimum verify the examples in `examples/` that exercise the changed code paths. Stale examples give users broken copy-paste snippets and mask API incompatibilities.
+
+**Detection — flag when ALL of these are true:**
+
+- PR modifies files under `packages/ai/src/`
+- PR does NOT modify any files under `examples/`
+- The changed source files export public API surface (entry points, middleware, scorers, wrapTool, withSpan, onlineEval, feedback, config)
+
+**What to flag:**
+
+- "This PR changes public SDK surface in `<file>` but no examples were updated. Please verify the examples in `examples/` still work, or update them to reflect the new behavior."
+
+**Exceptions — do NOT flag if:**
+
+- Changes are purely internal (unexported helpers, type narrowing, refactors with no public API change)
+- Changes only affect test files, CI config, or documentation
+
 ## Excluded Paths
 
 - **DO NOT** review the contents of the `.cursor/` directory


### PR DESCRIPTION
Adds a bug bot rule to flag PRs that change public SDK surface without updating examples.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to internal review guidelines; no runtime behavior or shipped code is affected.
> 
> **Overview**
> Adds a new **"Example Staleness After SDK Changes"** rule to `.cursor/BUGBOT.md` instructing the bug bot to flag PRs that modify public SDK code under `packages/ai/src/` without corresponding updates in `examples/`.
> 
> Defines detection criteria, the expected reviewer comment, and exceptions for internal-only or non-SDK changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 264bcf56b5d65eb8c77f93d5f992a7179755a0b0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->