### PR TITLE
online-evals: propagate eval.name to scorer spans

### DIFF
--- a/packages/ai/test/online-evals/executor.test.ts
+++ b/packages/ai/test/online-evals/executor.test.ts
@@ -515,6 +515,52 @@ describe('onlineEval', () => {
         message: 'Test error',
       });
     });
+
+    it('sets eval.name on scorer spans when name is provided in meta', async () => {
+      const scorer = createTestScorer('resolved', async () => ({ score: 1 }));
+
+      await onlineEval(
+        { capability: 'session_outcome', name: 'anton-agent' },
+        { output: baseOutput, scorers: [scorer] },
+      );
+
+      expect(mockScorerSpan.setAttributes).toHaveBeenCalledWith(
+        expect.objectContaining({
+          'eval.name': 'anton-agent',
+        }),
+      );
+    });
+
+    it('sets eval.name on eval span when name is provided in meta', async () => {
+      const scorer = createTestScorer('resolved', async () => ({ score: 1 }));
+
+      await onlineEval(
+        { capability: 'session_outcome', name: 'anton-agent' },
+        { output: baseOutput, scorers: [scorer] },
+      );
+
+      expect(mockEvalSpan.setAttributes).toHaveBeenCalledWith(
+        expect.objectContaining({
+          'eval.name': 'anton-agent',
+        }),
+      );
+    });
+
+    it('sets eval.name on precomputed scorer spans', async () => {
+      await onlineEval(
+        { capability: 'session_outcome', name: 'anton-agent' },
+        {
+          output: baseOutput,
+          scorers: [{ name: 'resolved', score: 1, metadata: { status: 'RESOLVED' } }],
+        },
+      );
+
+      expect(mockScorerSpan.setAttributes).toHaveBeenCalledWith(
+        expect.objectContaining({
+          'eval.name': 'anton-agent',
+        }),
+      );
+    });
   });
 
   describe('scorer without name', () => {


### PR DESCRIPTION
onlineEval scorer spans were missing the `eval.name` attribute, causing
them to show up as `null` when dashboards group by `attributes.eval.name`.
The offline eval path (`eval.ts`) already sets `eval.name` on scorer spans,
but the online eval path never did.

Add an optional `name` field to `OnlineEvalMeta` and propagate it through
`executeOnlineEvalInternal` to the parent eval span and through
`executeScorer` to each scorer span. The field is optional so existing
callers are unaffected.

Callers pass `name` in the meta to get proper attribution:

```ts
await onlineEval(
  { capability: "session_outcome", name: "anton-agent" },
  { output, scorers: [{ name: "resolved", score: true }] },
);
```

Tests verify `eval.name` appears on function scorer spans, eval spans,
and precomputed scorer spans. All 3 tests fail without the fix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Telemetry-only changes that add an optional attribute and extend tests; existing callers are unaffected unless they opt into `meta.name`.
> 
> **Overview**
> Adds an optional `name` field to `OnlineEvalMeta` and propagates it through the online eval execution path.
> 
> When provided, `onlineEval` now sets `eval.name` on the parent eval span and passes it into `executeScorer` so *all* scorer spans (including precomputed results and failure paths) include the same `eval.name` attribute for consistent dashboard grouping. Tests were extended to assert `eval.name` is applied to eval spans, function scorer spans, and precomputed scorer spans.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4a4744b17d31a492c9efe65d8c4d2c5262014a62. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->