### PR TITLE
fix(ai): normalize boolean scores for precomputed online eval scorers

### DIFF
--- a/packages/ai/src/evals/normalize-score.ts
+++ b/packages/ai/src/evals/normalize-score.ts
@@ -1,0 +1,19 @@
+import { Attr } from '../otel/semconv/attributes';
+import type { Score } from './scorer.types';
+
+/**
+ * Normalizes a boolean score to numeric (1/0) and adds eval.score.is_boolean
+ * to metadata. Numbers and null pass through unchanged.
+ */
+export function normalizeBooleanScore(
+  score: Score['score'],
+  metadata?: Record<string, unknown>,
+): { score: number | null; metadata?: Record<string, unknown> } {
+  if (typeof score !== 'boolean') {
+    return { score, metadata };
+  }
+  return {
+    score: score ? 1 : 0,
+    metadata: { ...metadata, [Attr.Eval.Score.IsBoolean]: true },
+  };
+}

--- a/packages/ai/src/evals/scorer.factory.ts
+++ b/packages/ai/src/evals/scorer.factory.ts
@@ -1,5 +1,5 @@
-import { Attr } from '../otel/semconv/attributes';
 import type { ValidateName } from '../util/name-validation';
+import { normalizeBooleanScore } from './normalize-score';
 import type { Score, Scorer, ScorerOptions } from './scorer.types';
 
 // Helper to force TypeScript to evaluate/simplify types
@@ -74,24 +74,9 @@ export function createScorer<
       return { score: res };
     }
     if (typeof res === 'boolean') {
-      return {
-        score: res ? 1 : 0,
-        metadata: {
-          [Attr.Eval.Score.IsBoolean]: true,
-        },
-      };
+      return normalizeBooleanScore(res);
     }
-    // Score object with boolean score - convert and merge is_boolean into metadata
-    if (typeof res.score === 'boolean') {
-      return {
-        score: res.score ? 1 : 0,
-        metadata: {
-          ...res.metadata,
-          [Attr.Eval.Score.IsBoolean]: true,
-        },
-      };
-    }
-    return res;
+    return normalizeBooleanScore(res.score, res.metadata);
   };
 
   const scorer: any = (args: TArgs) => {

--- a/packages/ai/test/evals/normalize-score.test.ts
+++ b/packages/ai/test/evals/normalize-score.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { Attr } from '../../src/otel/semconv/attributes';
+import { normalizeBooleanScore } from '../../src/evals/normalize-score';
+
+describe('normalizeBooleanScore', () => {
+  it('converts true to 1 with is_boolean metadata', () => {
+    expect(normalizeBooleanScore(true)).toEqual({
+      score: 1,
+      metadata: { [Attr.Eval.Score.IsBoolean]: true },
+    });
+  });
+
+  it('converts false to 0 with is_boolean metadata', () => {
+    expect(normalizeBooleanScore(false)).toEqual({
+      score: 0,
+      metadata: { [Attr.Eval.Score.IsBoolean]: true },
+    });
+  });
+
+  it('merges is_boolean into existing metadata', () => {
+    expect(normalizeBooleanScore(true, { reason: 'exact match' })).toEqual({
+      score: 1,
+      metadata: { reason: 'exact match', [Attr.Eval.Score.IsBoolean]: true },
+    });
+  });
+
+  it('passes through numbers unchanged', () => {
+    expect(normalizeBooleanScore(0.75)).toEqual({
+      score: 0.75,
+      metadata: undefined,
+    });
+  });
+
+  it('passes through numbers with existing metadata unchanged', () => {
+    const metadata = { source: 'cache' };
+    expect(normalizeBooleanScore(0.5, metadata)).toEqual({
+      score: 0.5,
+      metadata: { source: 'cache' },
+    });
+  });
+
+  it('passes through null unchanged', () => {
+    expect(normalizeBooleanScore(null)).toEqual({
+      score: null,
+      metadata: undefined,
+    });
+  });
+
+  it('passes through null with existing metadata unchanged', () => {
+    expect(normalizeBooleanScore(null, { error: 'timeout' })).toEqual({
+      score: null,
+      metadata: { error: 'timeout' },
+    });
+  });
+});


### PR DESCRIPTION
## Overview

Precomputed `ScorerResult` objects passed to `onlineEval()` with boolean scores (`true`/`false`) were written directly to OTel span attributes without conversion. The console's `ScorePanel` expects `eval.score.value` to be a number and `eval.score.is_boolean` in the metadata JSON for Pass/Fail badges — neither condition was met, so the UI rendered blanks.

Function scorers created with `Scorer()` already normalized booleans via the factory; only precomputed results bypassed this path.

This extracts the boolean→number normalization into a shared `normalizeBooleanScore` utility and applies it in `setScorerSpanAttrs` so precomputed boolean scores are handled identically to function scorer booleans.

## Showcase

N/A — no visual changes, fix is in telemetry attribute output.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, well-tested refactor that only affects score normalization and telemetry attribute formatting; minimal behavioral surface area outside eval observability.
> 
> **Overview**
> Fixes inconsistent handling of boolean eval scores by extracting boolean→numeric normalization into a shared `normalizeBooleanScore` helper.
> 
> `createScorer` now delegates all boolean and `Score`-object normalization through this helper, and `online-evals` span attribute emission (`setScorerSpanAttrs`) normalizes *precomputed* `ScorerResult` booleans before writing `eval.score.value` and metadata. Adds focused unit tests covering the helper and precomputed boolean score telemetry output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 281f4964c909bcf108c14da2394743253e949f08. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->