### PR TITLE
feat(ai): add eval.case.scores summary attribute to online evals

### DIFF
--- a/packages/ai/src/online-evals/onlineEval.ts
+++ b/packages/ai/src/online-evals/onlineEval.ts
@@ -350,7 +350,19 @@ async function executeOnlineEvalInternal<
     const failedCount = Object.values(results).filter((result) => result.error).length;
     const ranCount = Object.keys(results).length;
 
+    const scoresSummary: Record<string, ScorerResult> = {};
+    for (const [name, result] of Object.entries(results)) {
+      scoresSummary[name] = {
+        name: result.name,
+        score: result.score,
+        ...(result.metadata &&
+          Object.keys(result.metadata).length > 0 && { metadata: result.metadata }),
+        ...(result.error && { error: result.error }),
+      };
+    }
+
     evalSpan.setAttributes({
+      [Attr.Eval.Case.Scores]: JSON.stringify(scoresSummary),
       'axiom.eval.online.scorers.total': normalizedScorers.length,
       'axiom.eval.online.scorers.ran': ranCount,
       'axiom.eval.online.scorers.sampled_out': sampledOutCount,


### PR DESCRIPTION
## Summary

- Add a JSON-serialized `eval.case.scores` span attribute to online eval spans that captures each scorer's name, score, metadata (when present), and error (when failed)
- Sampled-out scorers are excluded from the summary
- Comprehensive test coverage for all score summary scenarios (success, failure, metadata, sampled-out, mixed)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new span attribute and tests without changing scoring execution or persistence; primary risk is telemetry payload size/format expectations.
> 
> **Overview**
> Online eval spans now set a JSON-serialized `eval.case.scores` attribute that summarizes each executed scorer’s `name`, `score`, optional non-empty `metadata`, and optional `error` (with sampled-out scorers omitted).
> 
> Adds focused unit tests covering single/multiple scorers, metadata inclusion rules, failure formatting (`score: null` + `error`), and mixed sampled-out scenarios to lock in the telemetry contract.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 958ce7ab47576568445604cef3aaa0e34ea3c7fe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->