### PR TITLE
fix(ai): add 'offline' tag to offline eval spans

### DIFF
--- a/packages/ai/src/evals/eval.ts
+++ b/packages/ai/src/evals/eval.ts
@@ -266,7 +266,7 @@ async function registerEval<
             [Attr.Eval.Name]: evalName,
             [Attr.Eval.Version]: evalVersion,
             [Attr.Eval.Type]: 'regression', // TODO: where to get experiment type value from?
-            [Attr.Eval.Tags]: [],
+            [Attr.Eval.Tags]: JSON.stringify(['offline']),
             [Attr.Eval.Collection.ID]: 'custom', // TODO: where to get collection split value from?
             [Attr.Eval.Collection.Name]: 'custom', // TODO: where to get collection name from?
             [Attr.Eval.Collection.Size]: collection.length,
@@ -358,9 +358,6 @@ async function registerEval<
         if (instrumentationError) {
           throw instrumentationError;
         }
-
-        const tags: string[] = ['offline'];
-        suiteSpan?.setAttribute(Attr.Eval.Tags, JSON.stringify(tags));
 
         // Aggregate out-of-scope flags for evaluation-level reporting
         const flagSummary = new Map<string, OutOfScopeFlag>();
@@ -550,6 +547,7 @@ async function registerEval<
                               {
                                 attributes: {
                                   [Attr.GenAI.Operation.Name]: 'eval.score',
+                                  [Attr.Eval.Tags]: JSON.stringify(['offline']),
                                   [Attr.Eval.ID]: evalId,
                                   [Attr.Eval.Name]: evalName,
                                   [Attr.Eval.Version]: evalVersion,


### PR DESCRIPTION
## Summary

- Set `eval.tags` to `["offline"]` on the suite span at creation time instead of starting empty and patching in `afterAll`
- Add `eval.tags: ["offline"]` to offline scorer spans, matching the online eval pattern where scorer spans carry `["online"]`
- Removes the redundant late-set in `afterAll` since the tag is now set upfront

This brings offline eval telemetry into parity with online evals, where both the parent eval span and each scorer span carry the appropriate tag from the start.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small telemetry-only change that adjusts span attributes and removes redundant post-run mutation; no effect on eval execution logic or data flow.
> 
> **Overview**
> Offline evaluation spans now include `eval.tags` set to `['offline']` from the moment the suite span is created, instead of being patched in `afterAll`.
> 
> Scorer spans created during offline eval trials also now carry the same `['offline']` tag to match the tagging behavior used by online eval scoring spans.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1e6c0386281d67ed207ea6bd1f469f4b18cbb406. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->