### PR TITLE
ci: add kitchen-sink build to vitest entrypoints workflow

### DIFF
--- a/.github/workflows/check-vitest-entrypoints.yaml
+++ b/.github/workflows/check-vitest-entrypoints.yaml
@@ -6,12 +6,14 @@ on:
       - main
     paths:
       - 'packages/ai/**'
+      - 'examples/kitchen-sink/**'
       - '.github/workflows/check-vitest-entrypoints.yaml'
   pull_request:
     branches:
       - main
     paths:
       - 'packages/ai/**'
+      - 'examples/kitchen-sink/**'
       - '.github/workflows/check-vitest-entrypoints.yaml'
 
 env:
@@ -34,3 +36,10 @@ jobs:
       - run: pnpm install --frozen-lockfile --ignore-scripts
       - run: pnpm -C packages/ai build
       - run: pnpm -C packages/ai check:vitest-entrypoints
+      - name: Verify kitchen-sink builds without vitest
+        run: |
+          # vitest is resolvable through the axiom workspace:* symlink
+          # (kitchen-sink -> packages/ai/node_modules/vitest). Remove it
+          # so next build fails if any entrypoint leaks a vitest import.
+          rm -rf packages/ai/node_modules/vitest packages/ai/node_modules/@vitest
+          pnpm --filter kitchen-sink build


### PR DESCRIPTION
Adds an explicit `next build` step for the kitchen-sink example app in the `check-vitest-entrypoints` workflow and expands path filters to also trigger on `examples/kitchen-sink/**` changes.

This closes the gap where the existing dist-scanning guard (`check-vitest-entrypoints.mjs`) verifies entry points don't leak vitest, but no test verified that a downstream consumer can actually build for production without vitest being resolvable.

Closes AI-194

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change that tightens a guardrail against leaking `vitest` imports; no production code changes, with minimal risk beyond potential new CI failures/time.
> 
> **Overview**
> Extends the `check-vitest-entrypoints` GitHub Actions workflow to also trigger on `examples/kitchen-sink/**` changes.
> 
> Adds a CI step that deletes `vitest` from `packages/ai/node_modules` and then runs `pnpm --filter kitchen-sink build`, ensuring the kitchen-sink example can production-build without `vitest` being resolvable (catching any leaked `vitest` imports from `packages/ai` entrypoints).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f1747bc9ba0d517239a29ea736dc4ba3ef76f79d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->