### PR TITLE
fix(ai): move online eval scorer counters to eval.* namespace

### DIFF
--- a/packages/ai/src/online-evals/onlineEval.ts
+++ b/packages/ai/src/online-evals/onlineEval.ts
@@ -370,10 +370,10 @@ async function executeOnlineEvalInternal<
 
     evalSpan.setAttributes({
       [Attr.Eval.Case.Scores]: JSON.stringify(scoresSummary),
-      'axiom.eval.online.scorers.total': normalizedScorers.length,
-      'axiom.eval.online.scorers.ran': ranCount,
-      'axiom.eval.online.scorers.sampled_out': sampledOutCount,
-      'axiom.eval.online.scorers.failed': failedCount,
+      [Attr.Eval.Online.Scorers.Total]: normalizedScorers.length,
+      [Attr.Eval.Online.Scorers.Ran]: ranCount,
+      [Attr.Eval.Online.Scorers.SampledOut]: sampledOutCount,
+      [Attr.Eval.Online.Scorers.Failed]: failedCount,
     });
 
     if (failedCount > 0) {

--- a/packages/ai/src/otel/semconv/attributes.ts
+++ b/packages/ai/src/otel/semconv/attributes.ts
@@ -43,6 +43,10 @@ import {
   ATTR_EVAL_CONFIG_FLAGS,
   ATTR_EVAL_CAPABILITY_NAME,
   ATTR_EVAL_STEP_NAME,
+  ATTR_EVAL_ONLINE_SCORERS_TOTAL,
+  ATTR_EVAL_ONLINE_SCORERS_RAN,
+  ATTR_EVAL_ONLINE_SCORERS_SAMPLED_OUT,
+  ATTR_EVAL_ONLINE_SCORERS_FAILED,
 } from './eval_proposal';
 
 import {
@@ -317,6 +321,14 @@ export const Attr = {
     },
     Tags: ATTR_EVAL_TAGS,
     Metadata: ATTR_EVAL_METADATA,
+    Online: {
+      Scorers: {
+        Total: ATTR_EVAL_ONLINE_SCORERS_TOTAL,
+        Ran: ATTR_EVAL_ONLINE_SCORERS_RAN,
+        SampledOut: ATTR_EVAL_ONLINE_SCORERS_SAMPLED_OUT,
+        Failed: ATTR_EVAL_ONLINE_SCORERS_FAILED,
+      },
+    },
     Collection: {
       ID: ATTR_EVAL_COLLECTION_ID,
       Name: ATTR_EVAL_COLLECTION_NAME,

--- a/packages/ai/src/otel/semconv/eval_proposal.ts
+++ b/packages/ai/src/otel/semconv/eval_proposal.ts
@@ -45,6 +45,11 @@ export const ATTR_EVAL_SCORE_SCORER = 'eval.score.scorer' as const;
 export const ATTR_EVAL_SCORE_METADATA = 'eval.score.metadata' as const;
 export const ATTR_EVAL_SCORE_AGGREGATION = 'eval.score.aggregation' as const;
 export const ATTR_EVAL_SCORE_TRIALS = 'eval.score.trials' as const;
+// online
+export const ATTR_EVAL_ONLINE_SCORERS_TOTAL = 'eval.online.scorers.total' as const;
+export const ATTR_EVAL_ONLINE_SCORERS_RAN = 'eval.online.scorers.ran' as const;
+export const ATTR_EVAL_ONLINE_SCORERS_SAMPLED_OUT = 'eval.online.scorers.sampled_out' as const;
+export const ATTR_EVAL_ONLINE_SCORERS_FAILED = 'eval.online.scorers.failed' as const;
 // user
 export const ATTR_EVAL_USER_NAME = 'eval.user.name';
 export const ATTR_EVAL_USER_EMAIL = 'eval.user.email';


### PR DESCRIPTION
## Summary

- Remove the `axiom.` prefix from the 4 online eval scorer counter span attributes (`total`, `ran`, `sampled_out`, `failed`) so they land under `attributes.eval.online.scorers` instead of `attributes.custom.axiom.eval.online.scorers` when ingested into Axiom
- Extract hardcoded attribute keys into `eval_proposal.ts` constants and expose them via `Attr.Eval.Online.Scorers.*`

Addresses the trace shape documented in [Online eval trace shape](https://www.notion.so/axiomhq/Online-eval-trace-shape-311fc65a301980d58e92d4d0a32b9202) (action item from today's deep dive).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only OpenTelemetry attribute keys/namespacing for online eval scorer counters; primary risk is dashboards/queries expecting the old `axiom.*` attribute names.
> 
> **Overview**
> Moves the four online-eval scorer counter span attributes (`total`, `ran`, `sampled_out`, `failed`) from hardcoded `axiom.eval.online.scorers.*` keys to standardized `eval.online.scorers.*` semantic-convention constants.
> 
> Adds the new `ATTR_EVAL_ONLINE_SCORERS_*` constants in `eval_proposal.ts` and exposes them via `Attr.Eval.Online.Scorers.*`, then updates `onlineEval.ts` to emit those attributes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 045b4cc9736b84a1c2c51c0ac68a24b2d7980fc2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->