### PR TITLE
fix: update entry points

### DIFF
--- a/packages/ai/typedoc.json
+++ b/packages/ai/typedoc.json
@@ -3,8 +3,8 @@
   "entryPoints": [
     "src/index.ts",
     "src/evals.ts",
-    "src/evals/scorers.ts",
-    "src/evals/aggregations.ts",
+    "src/scorers/scorers.ts",
+    "src/scorers/aggregations.ts",
     "src/evals/online.ts",
     "src/config.ts",
     "src/feedback.ts"


### PR DESCRIPTION
update entry points to the correct directory. aligning with the changes in https://github.com/axiomhq/ai/pull/269


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that only affects which TypeDoc pages get generated. Main risk is missing/incorrect docs output if paths are still wrong.
> 
> **Overview**
> Updates `packages/ai/typedoc.json` to point TypeDoc `entryPoints` for scorers and aggregations at `src/scorers/*` instead of the old `src/evals/*` paths, aligning documentation generation with the new module layout.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c103c131eb175ed4cd7f9825ca4677859e58ee9f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->