### PR TITLE
fix(evals): select query endpoint from edgeUrl vs url

### DIFF
--- a/packages/ai/src/evals/eval.service.ts
+++ b/packages/ai/src/evals/eval.service.ts
@@ -93,7 +93,7 @@ export const findEvaluationCases = async (
   evalId: string,
   config: ResolvedAxiomConfig,
 ): Promise<Evaluation | null> => {
-  const { dataset, edgeUrl, token, orgId } = resolveAxiomConnection(config);
+  const { dataset, edgeUrl, url, token, orgId } = resolveAxiomConnection(config);
 
   const apl = `['${dataset}'] | where trace_id == "${evalId}" | order by _time`;
 
@@ -103,8 +103,15 @@ export const findEvaluationCases = async (
     ...(orgId ? { 'X-AXIOM-ORG-ID': orgId } : {}),
   });
 
-  // Use edgeUrl for query operations
-  const resp = await fetch(`${edgeUrl}/v1/datasets/_apl?format=legacy`, {
+  // If edgeUrl is explicitly configured, use the edge query endpoint.
+  // Otherwise use the regular API query endpoint.
+  const hasExplicitEdgeUrl = !!config.eval.edgeUrl;
+  const queryBaseUrl = hasExplicitEdgeUrl ? edgeUrl : url;
+  const queryPath = hasExplicitEdgeUrl
+    ? '/v1/query/_apl?format=legacy'
+    : '/v1/datasets/_apl?format=legacy';
+
+  const resp = await fetch(`${queryBaseUrl}${queryPath}`, {
     headers: headers,
     method: 'POST',
     body: JSON.stringify({ apl }),
@@ -112,7 +119,9 @@ export const findEvaluationCases = async (
   const payload = await resp.json();
 
   if (!resp.ok) {
-    throw new Error(`Failed to query evaluation cases: ${payload.message || resp.statusText}`);
+    throw new Error(
+      `Failed to query evaluation cases: ${payload?.message || resp?.statusText || 'Unknown error'}`,
+    );
   }
 
   return payload.matches.length ? buildSpanTree(payload.matches) : null;


### PR DESCRIPTION
## Summary
- select eval baseline query endpoint deterministically based on config
- when `eval.edgeUrl` is set, use `/v1/query/_apl` on edge
- when `eval.edgeUrl` is not set, use `/v1/datasets/_apl` on API URL
- remove runtime fallback chaining between endpoints

## Verification
- `pnpm build` (packages/ai)
- `npm run eval -- support-agent-e2e-tool-use` (examples/kitchen-sink)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how eval case data is queried by switching base URL and API path depending on whether `config.eval.edgeUrl` is explicitly set, which could affect eval retrieval if deployments rely on the previous endpoint behavior.
> 
> **Overview**
> `findEvaluationCases` now selects the Axiom query endpoint deterministically: if `config.eval.edgeUrl` is explicitly set it uses the edge query route (`/v1/query/_apl`), otherwise it queries via the standard API URL (`/v1/datasets/_apl`).
> 
> The error handling for failed queries is also hardened to tolerate missing `payload.message`/`resp.statusText` and emit a fallback message.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 70a594b7cc8354f48f1199a8d61ab345b3b8aac6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->