### PR TITLE
feat: usage and finish reason on `chat <model> stream` spans

### DIFF
--- a/packages/ai/src/otel/middleware.ts
+++ b/packages/ai/src/otel/middleware.ts
@@ -103,6 +103,25 @@ const appendPromptMetadataToSpan = (
   }
 };
 
+function setStreamStepAttributes(
+  span: Span,
+  values: { inputTokens?: number; outputTokens?: number; finishReason?: string },
+) {
+  const inputTokens = ensureNumber(values.inputTokens);
+  if (inputTokens !== undefined) {
+    span.setAttribute(Attr.GenAI.Usage.InputTokens, inputTokens);
+  }
+
+  const outputTokens = ensureNumber(values.outputTokens);
+  if (outputTokens !== undefined) {
+    span.setAttribute(Attr.GenAI.Usage.OutputTokens, outputTokens);
+  }
+
+  if (values.finishReason) {
+    span.setAttribute(Attr.GenAI.Response.FinishReasons, JSON.stringify([values.finishReason]));
+  }
+}
+
 /**
  * Creates Axiom telemetry middleware for LanguageModelV1
  */
@@ -175,11 +194,13 @@ export function axiomAIMiddlewareV1(/* _config?: AxiomTelemetryConfig */): Langu
                 },
                 async flush(controller) {
                   try {
+                    const statsResult = stats.result;
+
                     await setPostCallAttributesV1(
                       span,
                       {
                         ...head,
-                        ...stats.result,
+                        ...statsResult,
                         toolCalls:
                           toolAggregator.result.length > 0 ? toolAggregator.result : undefined,
                         text: textAggregator.text,
@@ -187,6 +208,12 @@ export function axiomAIMiddlewareV1(/* _config?: AxiomTelemetryConfig */): Langu
                       context,
                       model,
                     );
+
+                    setStreamStepAttributes(childSpan, {
+                      inputTokens: statsResult.usage?.promptTokens,
+                      outputTokens: statsResult.usage?.completionTokens,
+                      finishReason: statsResult.finishReason,
+                    });
 
                     childSpan.end();
                     if (lease.owned) lease.end();
@@ -301,8 +328,9 @@ export function axiomAIMiddlewareV2(/* _config?: AxiomTelemetryConfig */): Langu
                 },
                 async flush(controller) {
                   try {
+                    const statsResult = stats.result;
                     const streamResult = {
-                      ...stats.result,
+                      ...statsResult,
                       content: [
                         ...(textAggregator.text
                           ? [{ type: 'text' as const, text: textAggregator.text }]
@@ -312,6 +340,12 @@ export function axiomAIMiddlewareV2(/* _config?: AxiomTelemetryConfig */): Langu
                     };
 
                     await setPostCallAttributesV2(span, streamResult, context, model);
+
+                    setStreamStepAttributes(childSpan, {
+                      inputTokens: statsResult.usage?.inputTokens,
+                      outputTokens: statsResult.usage?.outputTokens,
+                      finishReason: statsResult.finishReason,
+                    });
 
                     childSpan.end();
                     if (lease.owned) lease.end();
@@ -714,6 +748,12 @@ export function axiomAIMiddlewareV3(/* _config?: AxiomTelemetryConfig */): Langu
                       context,
                       model,
                     );
+
+                    setStreamStepAttributes(childSpan, {
+                      inputTokens: statsResult.usage?.inputTokens?.total,
+                      outputTokens: statsResult.usage?.outputTokens?.total,
+                      finishReason: statsResult.finishReason?.unified,
+                    });
 
                     childSpan.end();
                     if (lease.owned) lease.end();

--- a/packages/ai/test/otel/middleware.test.ts
+++ b/packages/ai/test/otel/middleware.test.ts
@@ -234,6 +234,11 @@ describe('Axiom Telemetry Middleware', () => {
       expect(parentSpan!.attributes['gen_ai.usage.output_tokens']).toBe(20);
       expect(parentSpan!.attributes['gen_ai.response.finish_reasons']).toBe('["stop"]');
 
+      // Stream child span should have per-step usage and finish reason attributes
+      expect(childSpan!.attributes['gen_ai.usage.input_tokens']).toBe(10);
+      expect(childSpan!.attributes['gen_ai.usage.output_tokens']).toBe(20);
+      expect(childSpan!.attributes['gen_ai.response.finish_reasons']).toBe('["stop"]');
+
       expect(parentSpan!.endTime).toBeDefined();
       expect(childSpan!.endTime).toBeDefined();
       expect(parentSpan!.startTime).toBeDefined();
@@ -255,6 +260,71 @@ describe('Axiom Telemetry Middleware', () => {
 
   describe('Span Ownership & Lifecycle', () => {
     describe('withSpan integration - middleware must not end user-owned spans', () => {
+      it('should capture tool-calls then stop finish reasons across two stream child spans (V1)', async () => {
+        const mockProvider = createMockProvider();
+        mockProvider.addStreamResponse('gpt-4-stream', {
+          chunks: ['first', ' response'],
+          finishReason: 'tool-calls',
+          usage: { promptTokens: 10, completionTokens: 20 },
+        });
+        mockProvider.addStreamResponse('gpt-4-stream', {
+          chunks: ['second', ' response'],
+          finishReason: 'stop',
+          usage: { promptTokens: 12, completionTokens: 24 },
+        });
+
+        const baseModel = mockProvider.languageModel('gpt-4-stream');
+        const instrumentedModel = wrapLanguageModel({
+          model: baseModel,
+          middleware: axiomAIMiddlewareV1(),
+        });
+
+        await withSpan({ capability: 'test', step: 'stream' }, async () => {
+          const first = streamText({
+            model: instrumentedModel,
+            prompt: 'First streaming call',
+          });
+          let firstText = '';
+          for await (const chunk of first.textStream) {
+            firstText += chunk;
+          }
+          expect(firstText).toBe('first response');
+
+          const second = streamText({
+            model: instrumentedModel,
+            prompt: 'Second streaming call',
+          });
+          let secondText = '';
+          for await (const chunk of second.textStream) {
+            secondText += chunk;
+          }
+          expect(secondText).toBe('second response');
+        });
+
+        const spans = otelTestSetup.getSpans();
+        const parentSpan = spans.find((s) => s.name === 'chat gpt-4-stream');
+        const streamSpans = spans.filter((s) => s.name === 'chat gpt-4-stream stream');
+
+        expect(parentSpan).toBeDefined();
+        expect(streamSpans).toHaveLength(2);
+        expect(parentSpan!.attributes['gen_ai.usage.input_tokens']).toBe(22);
+        expect(parentSpan!.attributes['gen_ai.usage.output_tokens']).toBe(44);
+        expect(parentSpan!.attributes['gen_ai.response.finish_reasons']).toBe('["stop"]');
+
+        const usagePairs = streamSpans
+          .map((s) => [
+            s.attributes['gen_ai.usage.input_tokens'],
+            s.attributes['gen_ai.usage.output_tokens'],
+            s.attributes['gen_ai.response.finish_reasons'],
+          ])
+          .sort((a, b) => Number(a[0]) - Number(b[0]));
+
+        expect(usagePairs).toEqual([
+          [10, 20, '["tool-calls"]'],
+          [12, 24, '["stop"]'],
+        ]);
+      });
+
       it('should not end user-owned span during streaming (V1)', async () => {
         const mockProvider = createMockProvider();
         mockProvider.addStreamResponse('gpt-4-stream', {


### PR DESCRIPTION
This PR adds token usage and finish_reason to `chat <model_name> stream` spans

See added test for more details on behavior

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 85a10fafc39c91a5c29f7b44b7538c5e801fa1fd. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->