### PR TITLE
feat: add  `vitestConfig` to axiom.config.ts

### DIFF
--- a/packages/ai/src/cli/commands/eval.command.ts
+++ b/packages/ai/src/cli/commands/eval.command.ts
@@ -83,7 +83,7 @@ export const loadEvalCommand = (program: Command, flagOverrides: FlagOverrides =
           const isGlobPattern = isGlob(target);
 
           // Load config file first to get defaults
-          const { config: loadedConfig } = await loadConfig('.');
+          const { config: loadedConfig, configPath } = await loadConfig('.');
 
           // Validate CLI flags against schema
           validateFlagOverrides(flagOverrides, loadedConfig.eval.flagSchema);
@@ -164,6 +164,7 @@ export const loadEvalCommand = (program: Command, flagOverrides: FlagOverrides =
               list: options.list,
               overrides: flagOverrides,
               config,
+              configPath,
               runId,
               consoleUrl: options.consoleUrl,
             });

--- a/packages/ai/src/config/index.ts
+++ b/packages/ai/src/config/index.ts
@@ -344,11 +344,7 @@ export function validateConfig(config: Partial<AxiomConfigBase>): ResolvedAxiomC
   }
 
   const vitestConfig = config.eval?.vitestConfig;
-  if (
-    vitestConfig !== undefined &&
-    vitestConfig !== false &&
-    typeof vitestConfig !== 'string'
-  ) {
+  if (vitestConfig !== undefined && vitestConfig !== false && typeof vitestConfig !== 'string') {
     errors.push('eval.vitestConfig must be a string path or false.');
   }
 

--- a/packages/ai/src/config/index.ts
+++ b/packages/ai/src/config/index.ts
@@ -180,6 +180,16 @@ export interface AxiomConfigBase {
      * @example ['**\/node_modules/**', '**\/.next/**']
      */
     exclude?: string[];
+    /**
+     * Optional Vitest config file to load for eval runs.
+     *
+     * When omitted or set to false, evals run without loading any Vitest config,
+     * keeping them isolated from the application's Vite/Vitest plugin graph.
+     *
+     * @default false
+     * @example './vitest.eval.config.ts'
+     */
+    vitestConfig?: string | false;
   };
 }
 
@@ -286,6 +296,7 @@ export function createPartialDefaults(): Partial<AxiomConfigBase> {
       include: [...DEFAULT_EVAL_INCLUDE],
       exclude: [],
       timeoutMs: 60_000,
+      vitestConfig: false,
     },
   };
 }
@@ -330,6 +341,15 @@ export function validateConfig(config: Partial<AxiomConfigBase>): ResolvedAxiomC
     errors.push(
       'eval.instrumentation must be a function returning OTEL setup information or null.',
     );
+  }
+
+  const vitestConfig = config.eval?.vitestConfig;
+  if (
+    vitestConfig !== undefined &&
+    vitestConfig !== false &&
+    typeof vitestConfig !== 'string'
+  ) {
+    errors.push('eval.vitestConfig must be a string path or false.');
   }
 
   if (errors.length > 0) {

--- a/packages/ai/src/config/loader.ts
+++ b/packages/ai/src/config/loader.ts
@@ -32,6 +32,7 @@ function customMerger(target: any, source: any): any {
  */
 export interface LoadConfigResult {
   config: ResolvedAxiomConfig;
+  configPath?: string;
 }
 
 /**
@@ -68,6 +69,7 @@ export async function loadConfig(cwd: string = process.cwd()): Promise<LoadConfi
 
     return {
       config: validatedConfig,
+      configPath: result._configFile,
     };
   } catch (error) {
     if (error instanceof AxiomCLIError) {

--- a/packages/ai/src/evals/run-vitest.ts
+++ b/packages/ai/src/evals/run-vitest.ts
@@ -1,5 +1,5 @@
 import c from 'tinyrainbow';
-import { resolve, join } from 'node:path';
+import { resolve, join, dirname } from 'node:path';
 import { mkdirSync, writeFileSync, unlinkSync, existsSync, readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
@@ -82,6 +82,7 @@ export const runVitest = async (
     list?: boolean;
     overrides?: Record<string, any>;
     config: ResolvedAxiomConfig;
+    configPath?: string;
     runId: string;
     consoleUrl?: string;
   },
@@ -133,11 +134,18 @@ export const runVitest = async (
 
   const evalTimeoutMs = opts.config?.eval?.timeoutMs || 60_000;
   const hookTimeoutMs = Math.max(evalTimeoutMs, 60_000);
+  const vitestConfig =
+    typeof opts.config.eval.vitestConfig === 'string'
+      ? resolve(
+          opts.configPath ? dirname(opts.configPath) : dir || process.cwd(),
+          opts.config.eval.vitestConfig,
+        )
+      : false;
 
   const vi = await createVitest(
     'test',
     {
-      config: false,
+      config: vitestConfig,
       root: dir ? dir : process.cwd(),
       mode: VITEST_MODE,
       include: opts.include,
@@ -147,7 +155,6 @@ export const runVitest = async (
       environment: 'node',
       browser: undefined,
       watch: opts.watch,
-      setupFiles: [],
       name: 'axiom:eval',
       printConsoleTrace: true,
       silent: false,
@@ -166,6 +173,7 @@ export const runVitest = async (
         runId: opts.runId,
         consoleUrl: opts.consoleUrl,
       },
+      ...(vitestConfig === false ? { setupFiles: [] } : {}),
     },
     {
       plugins: [tsconfigPaths({ root: dir || process.cwd() })],

--- a/packages/ai/src/evals/run-vitest.ts
+++ b/packages/ai/src/evals/run-vitest.ts
@@ -25,6 +25,18 @@ const getCurrentDir = (): string => {
 
 const evalsRunnerPath = resolve(getCurrentDir(), 'evals', 'custom-runner.js');
 
+export const resolveVitestConfigPath = (
+  vitestConfig: ResolvedAxiomConfig['eval']['vitestConfig'],
+  configPath?: string,
+  rootDir?: string,
+): string | false => {
+  if (typeof vitestConfig !== 'string') {
+    return false;
+  }
+
+  return resolve(configPath ? dirname(configPath) : rootDir || process.cwd(), vitestConfig);
+};
+
 const printCollectedEvals = (result: TestRunResult, rootDir: string) => {
   if (!result.testModules || result.testModules.length === 0) {
     console.log(c.yellow('\nNo evaluations found\n'));
@@ -134,13 +146,7 @@ export const runVitest = async (
 
   const evalTimeoutMs = opts.config?.eval?.timeoutMs || 60_000;
   const hookTimeoutMs = Math.max(evalTimeoutMs, 60_000);
-  const vitestConfig =
-    typeof opts.config.eval.vitestConfig === 'string'
-      ? resolve(
-          opts.configPath ? dirname(opts.configPath) : dir || process.cwd(),
-          opts.config.eval.vitestConfig,
-        )
-      : false;
+  const vitestConfig = resolveVitestConfigPath(opts.config.eval.vitestConfig, opts.configPath, dir);
 
   const vi = await createVitest(
     'test',

--- a/packages/ai/test/config/load-config.test.ts
+++ b/packages/ai/test/config/load-config.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { mkdtemp, rm, writeFile } from 'node:fs/promises';
-import { join } from 'node:path';
+import { basename, join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { loadConfig } from '../../src/config/loader';
 import { DEFAULT_EVAL_INCLUDE } from '../../src/config/index';
@@ -35,6 +35,7 @@ describe('loadConfig', () => {
       async (dir) => {
         const { config } = await loadConfig(dir);
         expect(config.eval.include).toEqual([...DEFAULT_EVAL_INCLUDE]);
+        expect(config.eval.vitestConfig).toBe(false);
       },
     );
   });
@@ -57,6 +58,26 @@ describe('loadConfig', () => {
       },
     );
   });
+
+  it('preserves a user provided vitest config path', async () => {
+    await withTempConfigDir(
+      `
+        module.exports = {
+          eval: {
+            token: 'test-token',
+            dataset: 'test-dataset',
+            vitestConfig: './vitest.eval.config.ts',
+          },
+        };
+      `,
+      async (dir) => {
+        const { config, configPath } = await loadConfig(dir);
+        expect(config.eval.vitestConfig).toBe('./vitest.eval.config.ts');
+        expect(configPath).toBeDefined();
+        expect(basename(configPath!)).toBe('axiom.config.cjs');
+      },
+    );
+  });
 });
 
 describe('resolveAxiomConnection', () => {
@@ -75,6 +96,7 @@ describe('resolveAxiomConnection', () => {
         include: [],
         exclude: [],
         timeoutMs: 60_000,
+        vitestConfig: false,
         ...overrides,
       },
     }) as ResolvedAxiomConfig;

--- a/packages/ai/test/evals/eval.trial-metadata.test.ts
+++ b/packages/ai/test/evals/eval.trial-metadata.test.ts
@@ -26,6 +26,7 @@ const createConfig = (): ResolvedAxiomConfig =>
       include: [],
       exclude: [],
       timeoutMs: 10_000,
+      vitestConfig: false,
     },
   }) as ResolvedAxiomConfig;
 

--- a/packages/ai/test/evals/instrument.test.ts
+++ b/packages/ai/test/evals/instrument.test.ts
@@ -36,6 +36,7 @@ const createConfig = (overrides: TestHookOverrides = {}) => {
       include: [],
       exclude: [],
       timeoutMs: 60_000,
+      vitestConfig: false,
     },
   } as ResolvedAxiomConfig;
 };

--- a/packages/ai/test/evals/reporter.test.ts
+++ b/packages/ai/test/evals/reporter.test.ts
@@ -29,6 +29,7 @@ describe('AxiomReporter', () => {
         include: [],
         exclude: [],
         timeoutMs: 60_000,
+        vitestConfig: false,
         orgId: 'test-org-id',
       },
     } as ResolvedAxiomConfig;

--- a/packages/ai/test/evals/run-vitest.integration.test.ts
+++ b/packages/ai/test/evals/run-vitest.integration.test.ts
@@ -1,0 +1,98 @@
+// @vitest-environment node
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { createVitest } from 'vitest/node';
+import { loadConfig } from '../../src/config/loader';
+import { resolveVitestConfigPath } from '../../src/evals/run-vitest';
+
+const writeTempFile = async (dir: string, file: string, contents: string) => {
+  await writeFile(join(dir, file), contents, 'utf8');
+};
+
+describe('vitest config integration', () => {
+  afterEach(() => {
+    delete (globalThis as any).__SDK_VERSION__;
+  });
+
+  it('loads setupFiles from vitest config referenced by axiom.config.ts', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'axiom-vitest-config-'));
+
+    try {
+      await writeTempFile(
+        dir,
+        'axiom.config.ts',
+        `
+          export default {
+            eval: {
+              url: 'https://api.axiom.co',
+              edgeUrl: 'https://api.axiom.co',
+              token: 'test-token',
+              dataset: 'test-dataset',
+              vitestConfig: './vitest.eval.config.ts',
+            },
+          };
+        `,
+      );
+
+      await writeTempFile(
+        dir,
+        'vitest.eval.config.ts',
+        `
+          import { defineConfig } from 'vitest/config';
+
+          export default defineConfig({
+            test: {
+              setupFiles: ['./setup.ts'],
+            },
+          });
+        `,
+      );
+
+      await writeTempFile(
+        dir,
+        'setup.ts',
+        `
+          (globalThis as any).__axiomVitestSetupLoaded = true;
+        `,
+      );
+
+      await writeTempFile(
+        dir,
+        'config-load.test.ts',
+        `
+          import { expect, it } from 'vitest';
+
+          it('loads setup from vitest config', () => {
+            expect((globalThis as any).__axiomVitestSetupLoaded).toBe(true);
+          });
+        `,
+      );
+
+      const { config, configPath } = await loadConfig(dir);
+      const vitestConfigPath = resolveVitestConfigPath(config.eval.vitestConfig, configPath, dir);
+
+      expect(vitestConfigPath).toBeTypeOf('string');
+
+      const vi = await createVitest('test', {
+        config: vitestConfigPath,
+        root: dir,
+        include: ['**/*.test.ts'],
+        watch: false,
+        silent: true,
+      });
+
+      try {
+        const result = await vi.start();
+        expect(result.unhandledErrors).toEqual([]);
+        expect(vi.state.getCountOfFailedTests()).toBe(0);
+      } finally {
+        await vi.close();
+      }
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/ai/test/evals/run-vitest.test.ts
+++ b/packages/ai/test/evals/run-vitest.test.ts
@@ -56,6 +56,7 @@ const resolvedConfig: ResolvedAxiomConfig = {
     timeoutMs: 60_000,
     include: ['**/*.eval.ts'],
     exclude: ['**/node_modules/**'],
+    vitestConfig: false,
   },
 };
 
@@ -142,9 +143,41 @@ describe('runVitest', () => {
         config: false,
         mode: 'eval',
         name: 'axiom:eval',
+        setupFiles: [],
       }),
       expect.any(Object),
     );
+  });
+
+  it('uses an explicit vitest config path when configured', async () => {
+    const vitest = createVitestInstance();
+
+    mocks.createVitest.mockResolvedValue(vitest);
+
+    await expect(
+      runVitest('.', {
+        ...baseOptions,
+        configPath: '/tmp/project/axiom.config.ts',
+        config: {
+          ...resolvedConfig,
+          eval: {
+            ...resolvedConfig.eval,
+            vitestConfig: './vitest.eval.config.ts',
+          },
+        },
+      }),
+    ).rejects.toThrow('process.exit:0');
+
+    expect(mocks.createVitest).toHaveBeenCalledWith(
+      'test',
+      expect.objectContaining({
+        config: '/tmp/project/vitest.eval.config.ts',
+        mode: 'eval',
+        name: 'axiom:eval',
+      }),
+      expect.any(Object),
+    );
+    expect(mocks.createVitest.mock.calls[0]?.[1]).not.toHaveProperty('setupFiles');
   });
 
   it('exits 0 after a successful non-watch run', async () => {


### PR DESCRIPTION
Resolves https://github.com/axiomhq/ai/issues/303

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `axiom eval` boots Vitest by optionally loading a user-supplied Vitest config, which can alter plugin/setup behavior and affect eval execution environment. Default remains isolated (`config: false`), but misconfigured paths or config side effects could change runtime outcomes.
> 
> **Overview**
> Adds `eval.vitestConfig` to `axiom.config.*` to optionally load a Vitest config file during eval runs (default `false` to keep evals isolated from app/Vite plugin graphs).
> 
> Plumbs the discovered `axiom.config` file path through `loadConfig`/CLI into `runVitest`, resolves the Vitest config path relative to the config location, and conditionally preserves the previous “no config” behavior (including explicit empty `setupFiles`) when `vitestConfig` is disabled. Updates and adds tests, including an integration test verifying Vitest `setupFiles` are applied when referenced via `axiom.config.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a65fa4e1de6f231b26b07b02bc75c65c6e2ce3dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->